### PR TITLE
fix fleet and introduce lifecycle properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.gocache
 
 website/vendor
 

--- a/docs/resources/fleet.md
+++ b/docs/resources/fleet.md
@@ -187,6 +187,7 @@ resource "awsappstream_fleet" "on_demand_multi_session" {
 
 - `compute_capacity` (Attributes) Specifies the desired capacity for the fleet. Exactly one of `desired_instances` or `desired_sessions` must be specified for non-elastic fleets. These attributes are mutually exclusive. (see [below for nested schema](#nestedatt--compute_capacity))
 - `description` (String) The fleet description, if set.
+- `desired_state` (String) The runtime fleet state to enforce after create and update operations. Valid values are `INHERIT`, `RUNNING`, and `STOPPED`. The default value is `INHERIT`, which preserves the fleet's existing runtime state.
 - `disable_imds_v1` (Boolean) Whether Instance Metadata Service Version 1 (IMDSv1) is disabled for the AppStream fleet. If `true`, only IMDSv2 is enabled. If `false`, both IMDSv1 and IMDSv2 are enabled.
 - `disconnect_timeout_in_seconds` (Number) The amount of time that a disconnected session is allowed to remain active.
 - `display_name` (String) The name displayed to users in the AppStream user interface.
@@ -204,6 +205,7 @@ resource "awsappstream_fleet" "on_demand_multi_session" {
 - `session_script_s3_location` (Attributes) Specifies the S3 location of the session scripts configuration ZIP file. This setting applies only to elastic fleets. (see [below for nested schema](#nestedatt--session_script_s3_location))
 - `stream_view` (String) Controls which streaming protocol views are enabled.
 - `tags` (Map of String) A map of tags assigned to the fleet.
+- `update_behavior` (String) Controls how updates are handled when AWS requires the fleet to be stopped. Valid values are `AUTO_STOP_START` and `FAIL_IF_RUNNING`. If omitted, `AUTO_STOP_START` behavior is used.
 - `usb_device_filter_strings` (Set of String) Defines which USB devices can be redirected to streaming sessions when using the Windows native client. This setting is supported only for Windows fleets. For non-Windows platforms or non-native clients, this configuration is accepted by AWS but ignored at runtime.
 - `vpc_config` (Attributes) The VPC configuration used by the fleet. This block is required for elastic fleets. (see [below for nested schema](#nestedatt--vpc_config))
 

--- a/internal/resources/fleet/lifecycle.go
+++ b/internal/resources/fleet/lifecycle.go
@@ -1,0 +1,45 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fleet
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+type desiredState string
+
+func (s desiredState) String() string {
+	return string(s)
+}
+
+const (
+	desiredStateInherit desiredState = "INHERIT"
+	desiredStateRunning desiredState = "RUNNING"
+	desiredStateStopped desiredState = "STOPPED"
+)
+
+func desiredStateFromPlan(v types.String) desiredState {
+	if v.IsNull() || v.IsUnknown() {
+		return desiredStateInherit
+	}
+
+	return desiredState(v.ValueString())
+}
+
+type updateBehavior string
+
+func (b updateBehavior) String() string {
+	return string(b)
+}
+
+const (
+	updateBehaviorAutoStopStart updateBehavior = "AUTO_STOP_START"
+	updateBehaviorFailIfRunning updateBehavior = "FAIL_IF_RUNNING"
+)
+
+func updateBehaviorFromPlan(v types.String) updateBehavior {
+	if v.IsNull() || v.IsUnknown() {
+		return updateBehaviorAutoStopStart
+	}
+
+	return updateBehavior(v.ValueString())
+}

--- a/internal/resources/fleet/lifecycle_test.go
+++ b/internal/resources/fleet/lifecycle_test.go
@@ -1,0 +1,89 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fleet
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestDesiredStateFromPlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   types.String
+		want desiredState
+	}{
+		{
+			name: "null_defaults_to_inherit",
+			in:   types.StringNull(),
+			want: desiredStateInherit,
+		},
+		{
+			name: "unknown_defaults_to_inherit",
+			in:   types.StringUnknown(),
+			want: desiredStateInherit,
+		},
+		{
+			name: "running",
+			in:   types.StringValue(desiredStateRunning.String()),
+			want: desiredStateRunning,
+		},
+		{
+			name: "inherit",
+			in:   types.StringValue(desiredStateInherit.String()),
+			want: desiredStateInherit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := desiredStateFromPlan(tt.in)
+			if got != tt.want {
+				t.Fatalf("got desired state %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateBehaviorFromPlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   types.String
+		want updateBehavior
+	}{
+		{
+			name: "null_defaults_to_auto",
+			in:   types.StringNull(),
+			want: updateBehaviorAutoStopStart,
+		},
+		{
+			name: "unknown_defaults_to_auto",
+			in:   types.StringUnknown(),
+			want: updateBehaviorAutoStopStart,
+		},
+		{
+			name: "configured",
+			in:   types.StringValue(updateBehaviorFailIfRunning.String()),
+			want: updateBehaviorFailIfRunning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := updateBehaviorFromPlan(tt.in)
+			if got != tt.want {
+				t.Fatalf("got update behavior %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/resources/fleet/resource_create.go
+++ b/internal/resources/fleet/resource_create.go
@@ -144,6 +144,17 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		}
 	}
 
+	if desiredStateFromPlan(plan.DesiredState) == desiredStateRunning {
+		err = r.ensureRunning(ctx, name)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Creating AWS AppStream Fleet",
+				fmt.Sprintf("Could not start fleet %q after successful create: %v", name, err),
+			)
+			return
+		}
+	}
+
 	newState, diags := r.readFleet(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/fleet/resource_delete.go
+++ b/internal/resources/fleet/resource_delete.go
@@ -35,7 +35,16 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 
 	name := state.Name.ValueString()
 
-	_, err := r.appstreamClient.DeleteFleet(ctx, &awsappstream.DeleteFleetInput{
+	_, err := r.ensureStopped(ctx, name)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting AWS AppStream Fleet",
+			fmt.Sprintf("Could not stop fleet %q for delete: %v", name, err),
+		)
+		return
+	}
+
+	_, err = r.appstreamClient.DeleteFleet(ctx, &awsappstream.DeleteFleetInput{
 		Name: aws.String(name),
 	})
 	if err != nil {

--- a/internal/resources/fleet/resource_model.go
+++ b/internal/resources/fleet/resource_model.go
@@ -62,6 +62,10 @@ type resourceModel struct {
 	Tags types.Map `tfsdk:"tags"`
 	// TagsAll is a map of tags, including default tags, assigned to the fleet (computed).
 	TagsAll types.Map `tfsdk:"tags_all"`
+	// DesiredState is the desired runtime state to enforce after create and update (optional).
+	DesiredState types.String `tfsdk:"desired_state"`
+	// UpdateBehavior controls how updates that require a stopped fleet are handled (optional).
+	UpdateBehavior types.String `tfsdk:"update_behavior"`
 	// ARN is the ARN of the AppStream fleet (computed).
 	ARN types.String `tfsdk:"arn"`
 	// CreatedTime is the timestamp when the fleet was created (computed).

--- a/internal/resources/fleet/resource_read.go
+++ b/internal/resources/fleet/resource_read.go
@@ -113,6 +113,8 @@ func (r *resource) readFleet(ctx context.Context, prior resourceModel) (*resourc
 		SessionScriptS3Location:        flattenSessionScriptS3Location(ctx, fleet.SessionScriptS3Location, &diags),
 		RootVolumeConfig:               flattenRootVolumeConfig(ctx, fleet.RootVolumeConfig, &diags),
 		Tags:                           types.MapNull(types.StringType),
+		DesiredState:                   prior.DesiredState,
+		UpdateBehavior:                 prior.UpdateBehavior,
 		ARN:                            util.StringOrNull(fleet.Arn),
 		CreatedTime:                    util.StringFromTime(fleet.CreatedTime),
 		State:                          types.StringValue(string(fleet.State)),

--- a/internal/resources/fleet/resource_schema.go
+++ b/internal/resources/fleet/resource_schema.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -388,6 +389,37 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 				MarkdownDescription: "A map of tags, including default tags, assigned to the fleet.",
 				Computed:            true,
 				ElementType:         types.StringType,
+			},
+			"desired_state": schema.StringAttribute{
+				Description: "Desired runtime state of the AppStream Fleet.",
+				MarkdownDescription: "The runtime fleet state to enforce after create and update operations. " +
+					"Valid values are `INHERIT`, `RUNNING`, and `STOPPED`. " +
+					"The default value is `INHERIT`, which preserves the fleet's existing runtime state.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(desiredStateInherit.String()),
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						desiredStateInherit.String(),
+						desiredStateRunning.String(),
+						desiredStateStopped.String(),
+					),
+				},
+			},
+			"update_behavior": schema.StringAttribute{
+				Description: "Update behavior for the AppStream Fleet lifecycle.",
+				MarkdownDescription: "Controls how updates are handled when AWS requires the fleet to be stopped. " +
+					"Valid values are `AUTO_STOP_START` and `FAIL_IF_RUNNING`. " +
+					"If omitted, `AUTO_STOP_START` behavior is used.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(updateBehaviorAutoStopStart.String()),
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						updateBehaviorAutoStopStart.String(),
+						updateBehaviorFailIfRunning.String(),
+					),
+				},
 			},
 			"arn": schema.StringAttribute{
 				Description:         "ARN of the AppStream Fleet.",

--- a/internal/resources/fleet/resource_schema.go
+++ b/internal/resources/fleet/resource_schema.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -59,6 +61,9 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 					"Either `image_name` or `image_arn` must be specified.",
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,100}$`),
@@ -73,6 +78,9 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 					"Either `image_name` or `image_arn` must be specified.",
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					util.ValidARNWithServiceAndResource("appstream", "image/"),
 				},
@@ -160,6 +168,9 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 				MarkdownDescription: "The maximum length of time that a streaming session can remain active.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int32{
 					int32validator.Between(600, 432000),
 				},
@@ -169,6 +180,9 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 				MarkdownDescription: "The amount of time that a disconnected session is allowed to remain active.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int32{
 					int32validator.Between(60, 36000),
 				},
@@ -180,6 +194,9 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 					"between 60 and 36000 to avoid AWS rounding behavior.",
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int32{
 					util.DurationWithStep(60, 36000, 60, true),
 				},
@@ -207,12 +224,18 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 					"If `false`, both IMDSv1 and IMDSv2 are enabled.",
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_default_internet_access": schema.BoolAttribute{
 				Description:         "Enable default internet access.",
 				MarkdownDescription: "Whether instances in the fleet have access to the internet.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"domain_join_info": schema.SingleNestedAttribute{
 				Description: "Active Directory domain join configuration.",

--- a/internal/resources/fleet/resource_update.go
+++ b/internal/resources/fleet/resource_update.go
@@ -193,17 +193,53 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 	restartAfter := false
 	var err error
 	mode := updateMode(state, plan)
+	updateBehavior := updateBehaviorFromPlan(plan.UpdateBehavior)
+	desiredState := desiredStateFromPlan(plan.DesiredState)
 
 	switch mode {
 	case fleetUpdateRequiresStop:
-		restartAfter, err = r.ensureStopped(ctx, name)
-		if err != nil {
+		switch updateBehavior {
+		case updateBehaviorAutoStopStart:
+			restartAfter, err = r.ensureStopped(ctx, name)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Updating AWS AppStream Fleet",
+					fmt.Sprintf("Could not stop fleet %q for update: %v", name, err),
+				)
+				return
+			}
+
+		case updateBehaviorFailIfRunning:
+			currentState, exists, err := r.currentFleetState(ctx, name)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Updating AWS AppStream Fleet",
+					fmt.Sprintf("Could not inspect fleet %q state for update: %v", name, err),
+				)
+				return
+			}
+
+			if exists && currentState != awstypes.FleetStateStopped {
+				resp.Diagnostics.AddError(
+					"Error Updating AWS AppStream Fleet",
+					fmt.Sprintf(
+						"Could not update fleet %q: update requires the fleet to be stopped, but current state is %q and update_behavior is %q.",
+						name,
+						string(currentState),
+						updateBehaviorFailIfRunning,
+					),
+				)
+				return
+			}
+
+		default:
 			resp.Diagnostics.AddError(
 				"Error Updating AWS AppStream Fleet",
-				fmt.Sprintf("Could not stop fleet %q for update: %v", name, err),
+				fmt.Sprintf("Could not update fleet %q: unsupported update_behavior %q", name, updateBehavior),
 			)
 			return
 		}
+
 	case fleetUpdateAllowedRunning:
 		// proceed normally
 	case fleetUpdateForbidden:
@@ -240,12 +276,40 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 		}
 	}
 
-	if mode == fleetUpdateRequiresStop && restartAfter {
+	switch {
+	case mode == fleetUpdateRequiresStop && desiredState == desiredStateRunning:
 		err = r.ensureRunning(ctx, name)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating AWS AppStream Fleet",
 				fmt.Sprintf("Could not start fleet %q after successful update: %v", name, err),
+			)
+			return
+		}
+	case mode == fleetUpdateRequiresStop && desiredState == desiredStateInherit && restartAfter:
+		err = r.ensureRunning(ctx, name)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Updating AWS AppStream Fleet",
+				fmt.Sprintf("Could not start fleet %q after successful update: %v", name, err),
+			)
+			return
+		}
+	case mode == fleetUpdateAllowedRunning && desiredState == desiredStateRunning:
+		err = r.ensureRunning(ctx, name)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Updating AWS AppStream Fleet",
+				fmt.Sprintf("Could not start fleet %q after successful update: %v", name, err),
+			)
+			return
+		}
+	case mode == fleetUpdateAllowedRunning && desiredState == desiredStateStopped:
+		_, err = r.ensureStopped(ctx, name)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Updating AWS AppStream Fleet",
+				fmt.Sprintf("Could not stop fleet %q after successful update: %v", name, err),
 			)
 			return
 		}
@@ -272,27 +336,38 @@ func wasRunning(state awstypes.FleetState) bool {
 	return state == awstypes.FleetStateRunning || state == awstypes.FleetStateStarting
 }
 
+func (r *resource) currentFleetState(ctx context.Context, name string) (state awstypes.FleetState, exists bool, err error) {
+	out, err := r.appstreamClient.DescribeFleets(ctx, &awsappstream.DescribeFleetsInput{
+		Names: []string{name},
+	})
+	if err != nil {
+		if util.IsAppStreamNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	if len(out.Fleets) == 0 {
+		return "", false, nil
+	}
+
+	return out.Fleets[0].State, true, nil
+}
+
 func (r *resource) ensureStopped(ctx context.Context, name string) (restartAfter bool, err error) {
 	stateCaptured := false
 
 	err = util.RetryOn(
 		ctx,
 		func(ctx context.Context) error {
-			out, err := r.appstreamClient.DescribeFleets(ctx, &awsappstream.DescribeFleetsInput{
-				Names: []string{name},
-			})
+			state, exists, err := r.currentFleetState(ctx, name)
 			if err != nil {
-				if util.IsAppStreamNotFound(err) {
-					return nil
-				}
 				return err
 			}
 
-			if len(out.Fleets) == 0 {
+			if !exists {
 				return nil
 			}
-
-			state := out.Fleets[0].State
 
 			if !stateCaptured {
 				restartAfter = wasRunning(state)
@@ -340,21 +415,14 @@ func (r *resource) ensureRunning(ctx context.Context, name string) error {
 	return util.RetryOn(
 		ctx,
 		func(ctx context.Context) error {
-			out, err := r.appstreamClient.DescribeFleets(ctx, &awsappstream.DescribeFleetsInput{
-				Names: []string{name},
-			})
+			state, exists, err := r.currentFleetState(ctx, name)
 			if err != nil {
-				if util.IsAppStreamNotFound(err) {
-					return nil
-				}
 				return err
 			}
 
-			if len(out.Fleets) == 0 {
+			if !exists {
 				return nil
 			}
-
-			state := out.Fleets[0].State
 
 			switch state {
 			case awstypes.FleetStateStopped:

--- a/internal/util/terraform_to_aws.go
+++ b/internal/util/terraform_to_aws.go
@@ -57,8 +57,10 @@ func OptionalStringUpdate(plan types.String, state types.String, setter func(*st
 	case plan.IsUnknown():
 		return
 	case !plan.IsNull():
-		v := plan.ValueString()
-		setter(&v)
+		if !state.IsUnknown() && !state.IsNull() && plan.ValueString() == state.ValueString() {
+			return
+		}
+		setter(plan.ValueStringPointer())
 	case plan.IsNull() && !state.IsNull():
 		var empty string
 		setter(&empty)

--- a/internal/util/terraform_to_aws_test.go
+++ b/internal/util/terraform_to_aws_test.go
@@ -212,6 +212,12 @@ func TestOptionalStringUpdate(t *testing.T) {
 			wantValue:  aws.String("new"),
 		},
 		{
+			name:       "plan_value_equals_state_noop",
+			plan:       types.StringValue("same"),
+			state:      types.StringValue("same"),
+			wantCalled: false,
+		},
+		{
 			name:       "plan_null_state_value_clears",
 			plan:       types.StringNull(),
 			state:      types.StringValue("old"),


### PR DESCRIPTION
## Related Issue

None

## Description

- fleet: unchanged strings are sent to update
- fleet: stabalize fleet plans
- fleet: fleet must be stopped to destroy
- fleet: desired_state and update_behavior lifecycle controls

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
