### PR TITLE
Refactor Retries

### DIFF
--- a/internal/resources/app_block/resource_create.go
+++ b/internal/resources/app_block/resource_create.go
@@ -64,13 +64,10 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	var out *awsappstream.CreateAppBlockOutput
-	err := util.RetryOn(
+	out, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			out, err = r.appstreamClient.CreateAppBlock(ctx, input)
-			return err
+		func(ctx context.Context) (*awsappstream.CreateAppBlockOutput, error) {
+			return r.appstreamClient.CreateAppBlock(ctx, input)
 		},
 		util.WithTimeout(createRetryTimeout),
 		util.WithInitBackoff(createRetryInitBackoff),

--- a/internal/resources/app_block_builder/resource_create.go
+++ b/internal/resources/app_block_builder/resource_create.go
@@ -57,13 +57,10 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	var out *awsappstream.CreateAppBlockBuilderOutput
-	err := util.RetryOn(
+	out, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			out, err = r.appstreamClient.CreateAppBlockBuilder(ctx, input)
-			return err
+		func(ctx context.Context) (*awsappstream.CreateAppBlockBuilderOutput, error) {
+			return r.appstreamClient.CreateAppBlockBuilder(ctx, input)
 		},
 		util.WithTimeout(createRetryTimeout),
 		util.WithInitBackoff(createRetryInitBackoff),

--- a/internal/resources/app_block_builder/resource_update.go
+++ b/internal/resources/app_block_builder/resource_update.go
@@ -148,12 +148,10 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 		}
 
 		var out *awsappstream.UpdateAppBlockBuilderOutput
-		err = util.RetryOn(
+		out, err = util.RetryOnValue(
 			ctx,
-			func(ctx context.Context) error {
-				var err error
-				out, err = r.appstreamClient.UpdateAppBlockBuilder(ctx, input)
-				return err
+			func(ctx context.Context) (*awsappstream.UpdateAppBlockBuilderOutput, error) {
+				return r.appstreamClient.UpdateAppBlockBuilder(ctx, input)
 			},
 			util.WithTimeout(updateRetryTimeout),
 			util.WithInitBackoff(updateRetryInitBackoff),

--- a/internal/resources/application/resource_create.go
+++ b/internal/resources/application/resource_create.go
@@ -62,13 +62,10 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	var out *awsappstream.CreateApplicationOutput
-	err := util.RetryOn(
+	out, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			out, err = r.appstreamClient.CreateApplication(ctx, input)
-			return err
+		func(ctx context.Context) (*awsappstream.CreateApplicationOutput, error) {
+			return r.appstreamClient.CreateApplication(ctx, input)
 		},
 		util.WithTimeout(createRetryTimeout),
 		util.WithInitBackoff(createRetryInitBackoff),

--- a/internal/resources/application/resource_update.go
+++ b/internal/resources/application/resource_update.go
@@ -111,7 +111,22 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 			return
 		}
 
-		_, err = r.appstreamClient.UpdateApplication(ctx, input)
+		err = util.RetryOn(
+			ctx,
+			func(ctx context.Context) error {
+				_, err := r.appstreamClient.UpdateApplication(ctx, input)
+				return err
+			},
+			util.WithTimeout(updateRetryTimeout),
+			util.WithInitBackoff(updateRetryInitBackoff),
+			util.WithMaxBackoff(updateRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_UpdateApplication.html
+			util.WithRetryOnFns(
+				util.IsConcurrentModificationException,
+				util.IsOperationNotPermittedException,
+			),
+		)
+
 		if err != nil {
 			if util.IsContextCanceled(err) {
 				return

--- a/internal/resources/application/retry.go
+++ b/internal/resources/application/retry.go
@@ -8,5 +8,9 @@ import "time"
 const (
 	createRetryTimeout     = 10 * time.Minute
 	createRetryInitBackoff = 5 * time.Second
-	createRetryMaxBackoff  = 1 * time.Minute
+	createRetryMaxBackoff  = 30 * time.Second
+
+	updateRetryTimeout     = 5 * time.Minute
+	updateRetryInitBackoff = 2 * time.Second
+	updateRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/associate_app_block_builder_app_block/resource_delete.go
+++ b/internal/resources/associate_app_block_builder_app_block/resource_delete.go
@@ -33,10 +33,28 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 	appBlockBuilderName := state.AppBlockBuilderName.ValueString()
 	appBlockARN := state.AppBlockARN.ValueString()
 
-	_, err := r.appstreamClient.DisassociateAppBlockBuilderAppBlock(ctx, &awsappstream.DisassociateAppBlockBuilderAppBlockInput{
-		AppBlockArn:         aws.String(appBlockARN),
-		AppBlockBuilderName: aws.String(appBlockBuilderName),
-	})
+	err := util.RetryOn(
+		ctx,
+		func(ctx context.Context) error {
+			_, err := r.appstreamClient.DisassociateAppBlockBuilderAppBlock(
+				ctx,
+				&awsappstream.DisassociateAppBlockBuilderAppBlockInput{
+					AppBlockArn:         aws.String(appBlockARN),
+					AppBlockBuilderName: aws.String(appBlockBuilderName),
+				},
+			)
+			return err
+		},
+		util.WithTimeout(deleteRetryTimeout),
+		util.WithInitBackoff(deleteRetryInitBackoff),
+		util.WithMaxBackoff(deleteRetryMaxBackoff),
+		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DisassociateAppBlockBuilderAppBlock.html
+		util.WithRetryOnFns(
+			util.IsConcurrentModificationException,
+			util.IsOperationNotPermittedException,
+		),
+	)
+
 	if err != nil {
 		if util.IsContextCanceled(err) {
 			return

--- a/internal/resources/associate_app_block_builder_app_block/retry.go
+++ b/internal/resources/associate_app_block_builder_app_block/retry.go
@@ -9,4 +9,8 @@ const (
 	createRetryTimeout     = 5 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
 	createRetryMaxBackoff  = 1 * time.Minute
+
+	deleteRetryTimeout     = 5 * time.Minute
+	deleteRetryInitBackoff = 2 * time.Second
+	deleteRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/associate_application_entitlement/resource_delete.go
+++ b/internal/resources/associate_application_entitlement/resource_delete.go
@@ -34,11 +34,28 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 	entitlementName := state.EntitlementName.ValueString()
 	applicationIdentifier := state.ApplicationIdentifier.ValueString()
 
-	_, err := r.appstreamClient.DisassociateApplicationFromEntitlement(ctx, &awsappstream.DisassociateApplicationFromEntitlementInput{
-		StackName:             aws.String(stackName),
-		EntitlementName:       aws.String(entitlementName),
-		ApplicationIdentifier: aws.String(applicationIdentifier),
-	})
+	err := util.RetryOn(
+		ctx,
+		func(ctx context.Context) error {
+			_, err := r.appstreamClient.DisassociateApplicationFromEntitlement(
+				ctx,
+				&awsappstream.DisassociateApplicationFromEntitlementInput{
+					StackName:             aws.String(stackName),
+					EntitlementName:       aws.String(entitlementName),
+					ApplicationIdentifier: aws.String(applicationIdentifier),
+				},
+			)
+			return err
+		},
+		util.WithTimeout(deleteRetryTimeout),
+		util.WithInitBackoff(deleteRetryInitBackoff),
+		util.WithMaxBackoff(deleteRetryMaxBackoff),
+		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DisassociateApplicationFromEntitlement.html
+		util.WithRetryOnFns(
+			util.IsOperationNotPermittedException,
+		),
+	)
+
 	if err != nil {
 		if util.IsContextCanceled(err) {
 			return

--- a/internal/resources/associate_application_entitlement/retry.go
+++ b/internal/resources/associate_application_entitlement/retry.go
@@ -6,7 +6,11 @@ package associate_application_entitlement
 import "time"
 
 const (
-	createRetryTimeout     = 3 * time.Minute
+	createRetryTimeout     = 5 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
 	createRetryMaxBackoff  = 30 * time.Second
+
+	deleteRetryTimeout     = 5 * time.Minute
+	deleteRetryInitBackoff = 2 * time.Second
+	deleteRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/associate_application_fleet/resource_delete.go
+++ b/internal/resources/associate_application_fleet/resource_delete.go
@@ -33,10 +33,28 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 	fleetName := state.FleetName.ValueString()
 	applicationARN := state.ApplicationARN.ValueString()
 
-	_, err := r.appstreamClient.DisassociateApplicationFleet(ctx, &awsappstream.DisassociateApplicationFleetInput{
-		FleetName:      aws.String(fleetName),
-		ApplicationArn: aws.String(applicationARN),
-	})
+	err := util.RetryOn(
+		ctx,
+		func(ctx context.Context) error {
+			_, err := r.appstreamClient.DisassociateApplicationFleet(
+				ctx,
+				&awsappstream.DisassociateApplicationFleetInput{
+					FleetName:      aws.String(fleetName),
+					ApplicationArn: aws.String(applicationARN),
+				},
+			)
+			return err
+		},
+		util.WithTimeout(deleteRetryTimeout),
+		util.WithInitBackoff(deleteRetryInitBackoff),
+		util.WithMaxBackoff(deleteRetryMaxBackoff),
+		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DisassociateApplicationFleet.html
+		util.WithRetryOnFns(
+			util.IsConcurrentModificationException,
+			util.IsOperationNotPermittedException,
+		),
+	)
+
 	if err != nil {
 		if util.IsContextCanceled(err) {
 			return

--- a/internal/resources/associate_application_fleet/retry.go
+++ b/internal/resources/associate_application_fleet/retry.go
@@ -6,7 +6,11 @@ package associate_application_fleet
 import "time"
 
 const (
-	createRetryTimeout     = 3 * time.Minute
+	createRetryTimeout     = 5 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
 	createRetryMaxBackoff  = 30 * time.Second
+
+	deleteRetryTimeout     = 5 * time.Minute
+	deleteRetryInitBackoff = 2 * time.Second
+	deleteRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/associate_fleet_stack/resource_delete.go
+++ b/internal/resources/associate_fleet_stack/resource_delete.go
@@ -33,10 +33,26 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 	fleetName := state.FleetName.ValueString()
 	stackName := state.StackName.ValueString()
 
-	_, err := r.appstreamClient.DisassociateFleet(ctx, &awsappstream.DisassociateFleetInput{
-		FleetName: aws.String(fleetName),
-		StackName: aws.String(stackName),
-	})
+	err := util.RetryOn(
+		ctx,
+		func(ctx context.Context) error {
+			_, err := r.appstreamClient.DisassociateFleet(ctx, &awsappstream.DisassociateFleetInput{
+				FleetName: aws.String(fleetName),
+				StackName: aws.String(stackName),
+			})
+			return err
+		},
+		util.WithTimeout(deleteRetryTimeout),
+		util.WithInitBackoff(deleteRetryInitBackoff),
+		util.WithMaxBackoff(deleteRetryMaxBackoff),
+		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DisassociateFleet.html
+		util.WithRetryOnFns(
+			util.IsConcurrentModificationException,
+			util.IsOperationNotPermittedException,
+			util.IsResourceInUseException,
+		),
+	)
+
 	if err != nil {
 		if util.IsContextCanceled(err) {
 			return

--- a/internal/resources/associate_fleet_stack/retry.go
+++ b/internal/resources/associate_fleet_stack/retry.go
@@ -8,5 +8,9 @@ import "time"
 const (
 	createRetryTimeout     = 5 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
-	createRetryMaxBackoff  = 1 * time.Minute
+	createRetryMaxBackoff  = 30 * time.Second
+
+	deleteRetryTimeout     = 5 * time.Minute
+	deleteRetryInitBackoff = 2 * time.Second
+	deleteRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/associate_user_stack/resource_delete.go
+++ b/internal/resources/associate_user_stack/resource_delete.go
@@ -35,15 +35,31 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 	userName := state.UserName.ValueString()
 	authenticationType := state.AuthenticationType.ValueString()
 
-	out, err := r.appstreamClient.BatchDisassociateUserStack(ctx, &awsappstream.BatchDisassociateUserStackInput{
-		UserStackAssociations: []awstypes.UserStackAssociation{
-			{
-				AuthenticationType: awstypes.AuthenticationType(authenticationType),
-				StackName:          aws.String(stackName),
-				UserName:           aws.String(userName),
-			},
+	out, err := util.RetryOnValue(
+		ctx,
+		func(ctx context.Context) (*awsappstream.BatchDisassociateUserStackOutput, error) {
+			return r.appstreamClient.BatchDisassociateUserStack(
+				ctx,
+				&awsappstream.BatchDisassociateUserStackInput{
+					UserStackAssociations: []awstypes.UserStackAssociation{
+						{
+							AuthenticationType: awstypes.AuthenticationType(authenticationType),
+							StackName:          aws.String(stackName),
+							UserName:           aws.String(userName),
+						},
+					},
+				},
+			)
 		},
-	})
+		util.WithTimeout(deleteRetryTimeout),
+		util.WithInitBackoff(deleteRetryInitBackoff),
+		util.WithMaxBackoff(deleteRetryMaxBackoff),
+		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_BatchDisassociateUserStack.html
+		util.WithRetryOnFns(
+			util.IsOperationNotPermittedException,
+		),
+	)
+
 	if err != nil {
 		if util.IsContextCanceled(err) {
 			return

--- a/internal/resources/associate_user_stack/retry.go
+++ b/internal/resources/associate_user_stack/retry.go
@@ -8,5 +8,9 @@ import "time"
 const (
 	createRetryTimeout     = 5 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
-	createRetryMaxBackoff  = 1 * time.Minute
+	createRetryMaxBackoff  = 30 * time.Second
+
+	deleteRetryTimeout     = 5 * time.Minute
+	deleteRetryInitBackoff = 2 * time.Second
+	deleteRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/directory_config/resource_update.go
+++ b/internal/resources/directory_config/resource_update.go
@@ -84,7 +84,23 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 			return
 		}
 
-		_, err := r.appstreamClient.UpdateDirectoryConfig(ctx, input)
+		err := util.RetryOn(
+			ctx,
+			func(ctx context.Context) error {
+				_, err := r.appstreamClient.UpdateDirectoryConfig(ctx, input)
+				return err
+			},
+			util.WithTimeout(updateRetryTimeout),
+			util.WithInitBackoff(updateRetryInitBackoff),
+			util.WithMaxBackoff(updateRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_UpdateDirectoryConfig.html
+			util.WithRetryOnFns(
+				util.IsConcurrentModificationException,
+				util.IsOperationNotPermittedException,
+				util.IsResourceInUseException,
+			),
+		)
+
 		if err != nil {
 			if util.IsContextCanceled(err) {
 				return

--- a/internal/resources/directory_config/retry.go
+++ b/internal/resources/directory_config/retry.go
@@ -9,4 +9,8 @@ const (
 	createRetryTimeout     = 2 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
 	createRetryMaxBackoff  = 30 * time.Second
+
+	updateRetryTimeout     = 2 * time.Minute
+	updateRetryInitBackoff = 2 * time.Second
+	updateRetryMaxBackoff  = 10 * time.Second
 )

--- a/internal/resources/entitlement/resource_update.go
+++ b/internal/resources/entitlement/resource_update.go
@@ -71,7 +71,22 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 			})
 		}
 
-		_, err := r.appstreamClient.UpdateEntitlement(ctx, input)
+		err := util.RetryOn(
+			ctx,
+			func(ctx context.Context) error {
+				_, err := r.appstreamClient.UpdateEntitlement(ctx, input)
+				return err
+			},
+			util.WithTimeout(updateRetryTimeout),
+			util.WithInitBackoff(updateRetryInitBackoff),
+			util.WithMaxBackoff(updateRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_UpdateEntitlement.html
+			util.WithRetryOnFns(
+				util.IsConcurrentModificationException,
+				util.IsOperationNotPermittedException,
+			),
+		)
+
 		if err != nil {
 			if util.IsContextCanceled(err) {
 				return

--- a/internal/resources/entitlement/retry.go
+++ b/internal/resources/entitlement/retry.go
@@ -9,4 +9,8 @@ const (
 	createRetryTimeout     = 5 * time.Minute
 	createRetryInitBackoff = 2 * time.Second
 	createRetryMaxBackoff  = 1 * time.Minute
+
+	updateRetryTimeout     = 5 * time.Minute
+	updateRetryInitBackoff = 2 * time.Second
+	updateRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/fleet/resource_create.go
+++ b/internal/resources/fleet/resource_create.go
@@ -96,13 +96,10 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	var out *awsappstream.CreateFleetOutput
-	err := util.RetryOn(
+	out, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			out, err = r.appstreamClient.CreateFleet(ctx, input)
-			return err
+		func(ctx context.Context) (*awsappstream.CreateFleetOutput, error) {
+			return r.appstreamClient.CreateFleet(ctx, input)
 		},
 		util.WithTimeout(createRetryTimeout),
 		util.WithInitBackoff(createRetryInitBackoff),

--- a/internal/resources/fleet/resource_update.go
+++ b/internal/resources/fleet/resource_update.go
@@ -294,12 +294,10 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 		}
 
 		var out *awsappstream.UpdateFleetOutput
-		err = util.RetryOn(
+		out, err = util.RetryOnValue(
 			ctx,
-			func(ctx context.Context) error {
-				var err error
-				out, err = r.appstreamClient.UpdateFleet(ctx, input)
-				return err
+			func(ctx context.Context) (*awsappstream.UpdateFleetOutput, error) {
+				return r.appstreamClient.UpdateFleet(ctx, input)
 			},
 			util.WithTimeout(updateRetryTimeout),
 			util.WithInitBackoff(updateRetryInitBackoff),

--- a/internal/resources/image_builder/resource_create.go
+++ b/internal/resources/image_builder/resource_create.go
@@ -70,13 +70,10 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	var out *awsappstream.CreateImageBuilderOutput
-	err := util.RetryOn(
+	out, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			out, err = r.appstreamClient.CreateImageBuilder(ctx, input)
-			return err
+		func(ctx context.Context) (*awsappstream.CreateImageBuilderOutput, error) {
+			return r.appstreamClient.CreateImageBuilder(ctx, input)
 		},
 		util.WithTimeout(createRetryTimeout),
 		util.WithInitBackoff(createRetryInitBackoff),

--- a/internal/resources/image_permission/resource_create.go
+++ b/internal/resources/image_permission/resource_create.go
@@ -53,8 +53,7 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 	err := util.RetryOn(
 		ctx,
 		func(ctx context.Context) error {
-			var err error
-			_, err = r.appstreamClient.UpdateImagePermissions(ctx, input)
+			_, err := r.appstreamClient.UpdateImagePermissions(ctx, input)
 			return err
 		},
 		util.WithTimeout(retryTimeout),

--- a/internal/resources/stack/resource_create.go
+++ b/internal/resources/stack/resource_create.go
@@ -71,13 +71,10 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	var out *awsappstream.CreateStackOutput
-	err := util.RetryOn(
+	out, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			out, err = r.appstreamClient.CreateStack(ctx, input)
-			return err
+		func(ctx context.Context) (*awsappstream.CreateStackOutput, error) {
+			return r.appstreamClient.CreateStack(ctx, input)
 		},
 		util.WithTimeout(createRetryTimeout),
 		util.WithInitBackoff(createRetryInitBackoff),

--- a/internal/resources/stack/resource_create.go
+++ b/internal/resources/stack/resource_create.go
@@ -82,7 +82,6 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateStack.html
 		util.WithRetryOnFns(
 			util.IsConcurrentModificationException,
-			util.IsOperationNotPermittedException,
 			util.IsResourceNotFoundException,
 		),
 	)

--- a/internal/resources/stack/resource_update.go
+++ b/internal/resources/stack/resource_update.go
@@ -163,7 +163,21 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 			return
 		}
 
-		out, err := r.appstreamClient.UpdateStack(ctx, input)
+		out, err := util.RetryOnValue(
+			ctx,
+			func(ctx context.Context) (*awsappstream.UpdateStackOutput, error) {
+				return r.appstreamClient.UpdateStack(ctx, input)
+			},
+			util.WithTimeout(updateRetryTimeout),
+			util.WithInitBackoff(updateRetryInitBackoff),
+			util.WithMaxBackoff(updateRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_UpdateStack.html
+			util.WithRetryOnFns(
+				util.IsConcurrentModificationException,
+				util.IsResourceInUseException,
+			),
+		)
+
 		if err != nil {
 			if util.IsContextCanceled(err) {
 				return

--- a/internal/resources/stack/retry.go
+++ b/internal/resources/stack/retry.go
@@ -8,5 +8,9 @@ import "time"
 const (
 	createRetryTimeout     = 10 * time.Minute
 	createRetryInitBackoff = 5 * time.Second
-	createRetryMaxBackoff  = 1 * time.Minute
+	createRetryMaxBackoff  = 30 * time.Second
+
+	updateRetryTimeout     = 5 * time.Minute
+	updateRetryInitBackoff = 2 * time.Second
+	updateRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/stack_theme/resource_update.go
+++ b/internal/resources/stack_theme/resource_update.go
@@ -89,7 +89,21 @@ func (r *resource) Update(ctx context.Context, req tfresource.UpdateRequest, res
 			return
 		}
 
-		_, err := r.appstreamClient.UpdateThemeForStack(ctx, input)
+		err := util.RetryOn(
+			ctx,
+			func(ctx context.Context) error {
+				_, err := r.appstreamClient.UpdateThemeForStack(ctx, input)
+				return err
+			},
+			util.WithTimeout(updateRetryTimeout),
+			util.WithInitBackoff(updateRetryInitBackoff),
+			util.WithMaxBackoff(updateRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_UpdateThemeForStack.html
+			util.WithRetryOnFns(
+				util.IsConcurrentModificationException,
+			),
+		)
+
 		if err != nil {
 			if util.IsContextCanceled(err) {
 				return

--- a/internal/resources/stack_theme/retry.go
+++ b/internal/resources/stack_theme/retry.go
@@ -8,5 +8,9 @@ import "time"
 const (
 	createRetryTimeout     = 10 * time.Minute
 	createRetryInitBackoff = 5 * time.Second
-	createRetryMaxBackoff  = 1 * time.Minute
+	createRetryMaxBackoff  = 30 * time.Second
+
+	updateRetryTimeout     = 5 * time.Minute
+	updateRetryInitBackoff = 2 * time.Second
+	updateRetryMaxBackoff  = 30 * time.Second
 )

--- a/internal/resources/user/resource_create.go
+++ b/internal/resources/user/resource_create.go
@@ -93,8 +93,7 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		err = util.RetryOn(
 			ctx,
 			func(ctx context.Context) error {
-				var err error
-				_, err = r.appstreamClient.DisableUser(ctx, &awsappstream.DisableUserInput{
+				_, err := r.appstreamClient.DisableUser(ctx, &awsappstream.DisableUserInput{
 					AuthenticationType: awstypes.AuthenticationType(authenticationType),
 					UserName:           aws.String(userName),
 				})

--- a/internal/resources/user/resource_create.go
+++ b/internal/resources/user/resource_create.go
@@ -48,20 +48,7 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		input.MessageAction = awstypes.MessageAction(plan.MessageAction.ValueString())
 	}
 
-	err := util.RetryOn(
-		ctx,
-		func(ctx context.Context) error {
-			_, err := r.appstreamClient.CreateUser(ctx, input)
-			return err
-		},
-		util.WithTimeout(createRetryTimeout),
-		util.WithInitBackoff(createRetryInitBackoff),
-		util.WithMaxBackoff(createRetryMaxBackoff),
-		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateUser.html
-		util.WithRetryOnFns(
-			util.IsOperationNotPermittedException,
-		),
-	)
+	_, err := r.appstreamClient.CreateUser(ctx, input)
 
 	if err != nil {
 		if util.IsResourceAlreadyExists(err) {

--- a/internal/resources/user/resource_read.go
+++ b/internal/resources/user/resource_read.go
@@ -68,7 +68,6 @@ func (r *resource) readUser(ctx context.Context, prior resourceModel) (*resource
 		util.WithMaxBackoff(readRetryMaxBackoff),
 		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DescribeUsers.html
 		util.WithRetryOnFns(
-			util.IsOperationNotPermittedException,
 			util.IsResourceNotFoundException,
 			isUserNotYetVisibleError,
 		),

--- a/internal/resources/user/resource_read.go
+++ b/internal/resources/user/resource_read.go
@@ -56,15 +56,12 @@ func (r *resource) Read(ctx context.Context, req tfresource.ReadRequest, resp *t
 }
 
 func (r *resource) readUser(ctx context.Context, prior resourceModel) (*resourceModel, diag.Diagnostics) {
-	var state *resourceModel
 	var diags diag.Diagnostics
 
-	err := util.RetryOn(
+	state, err := util.RetryOnValue(
 		ctx,
-		func(ctx context.Context) error {
-			var err error
-			state, err = r.readUserOnce(ctx, prior)
-			return err
+		func(ctx context.Context) (*resourceModel, error) {
+			return r.readUserOnce(ctx, prior)
 		},
 		util.WithTimeout(readRetryTimeout),
 		util.WithInitBackoff(readRetryInitBackoff),

--- a/internal/resources/user/retry.go
+++ b/internal/resources/user/retry.go
@@ -6,10 +6,6 @@ package user
 import "time"
 
 const (
-	createRetryTimeout     = 5 * time.Minute
-	createRetryInitBackoff = 2 * time.Second
-	createRetryMaxBackoff  = 30 * time.Second
-
 	disableRetryTimeout     = 3 * time.Minute
 	disableRetryInitBackoff = 2 * time.Second
 	disableRetryMaxBackoff  = 30 * time.Second

--- a/internal/util/retry.go
+++ b/internal/util/retry.go
@@ -85,6 +85,17 @@ func contextTerminationError(ctxErr, lastErr error) error {
 }
 
 func RetryOn(ctx context.Context, call func(context.Context) error, opts ...RetryOption) error {
+	_, err := RetryOnValue(
+		ctx,
+		func(ctx context.Context) (struct{}, error) {
+			return struct{}{}, call(ctx)
+		},
+		opts...,
+	)
+	return err
+}
+
+func RetryOnValue[T any](ctx context.Context, call func(context.Context) (T, error), opts ...RetryOption) (T, error) {
 	options := defaultRetryConfig()
 	for _, fn := range opts {
 		fn(options)
@@ -94,27 +105,30 @@ func RetryOn(ctx context.Context, call func(context.Context) error, opts ...Retr
 	defer cancel()
 
 	backoff := options.initBackoff
-	var lastErr error
+	var (
+		out     T
+		lastErr error
+	)
 
 	for {
 		if err := ctx.Err(); err != nil {
-			return contextTerminationError(err, lastErr)
+			return out, contextTerminationError(err, lastErr)
 		}
 
-		err := call(ctx)
+		out, err := call(ctx)
 		if err == nil {
-			return nil
+			return out, nil
 		}
 
 		if !shouldRetry(err, options.retryOnFns) {
-			return err
+			return out, err
 		}
 
 		lastErr = err
 
 		select {
 		case <-ctx.Done():
-			return contextTerminationError(ctx.Err(), lastErr)
+			return out, contextTerminationError(ctx.Err(), lastErr)
 		case <-time.After(backoff):
 		}
 

--- a/internal/util/retry_test.go
+++ b/internal/util/retry_test.go
@@ -154,3 +154,67 @@ func TestRetryOn_ContextCanceled(t *testing.T) {
 		t.Fatalf("error = %v, want context canceled", err)
 	}
 }
+
+func TestRetryOnValue_SuccessFirstTry(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	calls := 0
+	out, err := RetryOnValue(
+		ctx,
+		func(context.Context) (int, error) {
+			calls++
+			return 42, nil
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != 42 {
+		t.Fatalf("out = %d, want 42", out)
+	}
+
+	if calls != 1 {
+		t.Fatalf("call count = %d, want 1", calls)
+	}
+}
+
+func TestRetryOnValue_RetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	calls := 0
+	retryErr := errors.New("retry")
+
+	out, err := RetryOnValue(
+		ctx,
+		func(context.Context) (string, error) {
+			calls++
+			if calls < 3 {
+				return "", retryErr
+			}
+			return "done", nil
+		},
+		WithRetryOnFns(func(err error) bool {
+			return errors.Is(err, retryErr)
+		}),
+		WithInitBackoff(1*time.Millisecond),
+		WithMaxBackoff(2*time.Millisecond),
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != "done" {
+		t.Fatalf("out = %q, want %q", out, "done")
+	}
+
+	if calls != 3 {
+		t.Fatalf("call count = %d, want 3", calls)
+	}
+}


### PR DESCRIPTION
## Related Issue

Fixes: https://github.com/St3ffn/terraform-provider-aws-appstream/issues/67

## Description

This change improves retry behavior and retry ergonomics across AppStream resources, with a focus on update/delete reliability and clearer retry intent.

Key updates:
- Added generic `util.RetryOnValue[T]` to return AWS SDK call outputs directly from retry loops.
- Refactored `util.RetryOn` to delegate to `RetryOnValue`, keeping existing behavior while reducing duplicate retry logic.
- Added unit tests for `RetryOnValue` (`success first try`, `retry then success`).
- Migrated several create/update/read call sites from outer-scope output mutation to `RetryOnValue`:
  - `app_block`, `app_block_builder`, `application`, `fleet`, `image_builder`, `stack`, `user` read path.
- Added retries for update operations that previously executed a single API call:
  - `awsappstream_application`
  - `awsappstream_directory_config`
  - `awsappstream_entitlement`
  - `awsappstream_stack`
  - `awsappstream_stack_theme`
- Added retries for association delete operations to better handle transient AppStream state/lock windows:
  - `awsappstream_associate_fleet_stack`
  - `awsappstream_associate_application_fleet`
  - `awsappstream_associate_application_entitlement`
  - `awsappstream_associate_user_stack`
  - `awsappstream_associate_app_block_builder_app_block`
- Added and aligned retry constants for update/delete paths in the touched resources.
- Tuned selected create retry constants (timeout/backoff) for consistency with the updated retry strategy.
- Tightened retry scope for some flows to avoid retrying likely non-transient errors (for example, user create/read and stack create predicate adjustments).

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls in this pull request.
No access control, encryption, or logging control behavior was modified.