### PR TITLE
fix: awsappstream_copied_image rename fields, sourceImageName from prior

### DIFF
--- a/docs/resources/copied_image.md
+++ b/docs/resources/copied_image.md
@@ -3,22 +3,22 @@
 page_title: "awsappstream_copied_image Resource - AWS AppStream"
 subcategory: ""
 description: |-
-  Manages an AppStream image created by copying an existing image to another region. CopyImage is invoked using the provider-configured region (source region), while destination_region controls where the copied image is created. Copied images are immutable artifacts and are typically replaced when copy input settings change. AppStream CopyImage does not copy tags, so tags are managed separately by the provider. After terraform import, configure create-time-only attribute source_image_name explicitly because the provider does not reconstruct this value from imported state.
+  Manages an AppStream image created by copying an existing image to another region. CopyImage is invoked using the provider-configured region (source region), while destination_region controls where the copied image is created. Copied images are immutable artifacts and are typically replaced when copy input settings change. AppStream CopyImage does not copy tags, so tags are managed separately by the provider.
 ---
 
 # awsappstream_copied_image (Resource)
 
-Manages an AppStream image created by copying an existing image to another region. `CopyImage` is invoked using the provider-configured region (source region), while `destination_region` controls where the copied image is created. Copied images are immutable artifacts and are typically replaced when copy input settings change. AppStream `CopyImage` does not copy tags, so tags are managed separately by the provider. After `terraform import`, configure create-time-only attribute `source_image_name` explicitly because the provider does not reconstruct this value from imported state.
+Manages an AppStream image created by copying an existing image to another region. `CopyImage` is invoked using the provider-configured region (source region), while `destination_region` controls where the copied image is created. Copied images are immutable artifacts and are typically replaced when copy input settings change. AppStream `CopyImage` does not copy tags, so tags are managed separately by the provider.
 
 ## Example Usage
 
 ```terraform
 # minimal copied image
 resource "awsappstream_copied_image" "example" {
-  name               = "example-copied-image"
-  description        = "Copied image for development"
-  source_image_name  = "example-source-image"
-  destination_region = "us-east-1"
+  destination_image_name        = "example-copied-image"
+  destination_image_description = "Copied image for development"
+  destination_region            = "us-east-1"
+  source_image_name             = "example-source-image"
 
   tags = {
     Environment = "dev"
@@ -30,10 +30,10 @@ resource "awsappstream_copied_image" "example" {
 ```terraform
 # copied image protected from destroy
 resource "awsappstream_copied_image" "keep" {
-  name               = "example-copied-image-keep"
-  description        = "Copied image retained for rollback"
-  source_image_name  = "example-source-image"
-  destination_region = "us-east-1"
+  destination_image_name        = "example-copied-image-keep"
+  destination_image_description = "Copied image retained for rollback"
+  destination_region            = "us-east-1"
+  source_image_name             = "example-source-image"
 
   # Prevent accidental image deletion via `terraform destroy` or replacement plans.
   lifecycle {
@@ -53,13 +53,13 @@ resource "awsappstream_copied_image" "keep" {
 
 ### Required
 
+- `destination_image_name` (String) A unique destination name for the copied image. Changing this value forces the copied image to be replaced.
 - `destination_region` (String) The AWS region where the copied image is created. Changing this value forces the copied image to be replaced.
-- `name` (String) A unique destination name for the copied image. Changing this value forces the copied image to be replaced.
-- `source_image_name` (String) The name of the source image used for the copy operation. Changing this value forces the copied image to be replaced. After import, this create-time input must be set explicitly in configuration.
+- `source_image_name` (String) The name of the source image used for the copy operation. Changing this value forces the copied image to be replaced. AWS read APIs do not reliably return this value, so import requires it as the third segment of the import identifier.
 
 ### Optional
 
-- `description` (String) A description for the copied image. Changing this value forces the copied image to be replaced.
+- `destination_image_description` (String) A description for the copied image. Changing this value forces the copied image to be replaced.
 - `tags` (Map of String) A map of tags assigned to the copied image.
 
 ### Read-Only
@@ -70,7 +70,7 @@ resource "awsappstream_copied_image" "keep" {
 - `base_image_arn` (String) The ARN of the image from which this image was created.
 - `created_time` (String) The timestamp when the AppStream copied image was created, in RFC 3339 format.
 - `dynamic_app_providers_enabled` (String) Indicates whether dynamic app providers are enabled.
-- `id` (String) A synthetic identifier for the copied image, composed of the name and destination region. This value is managed by the provider and cannot be set manually.
+- `id` (String) A synthetic identifier for the copied image, composed of the destination image name, destination region, and source image name. This value is managed by the provider and cannot be set manually.
 - `image_builder_name` (String) The name of the image builder used to create the image, if applicable.
 - `image_builder_supported` (Boolean) Whether an AppStream image builder can be launched from this copied image.
 - `image_errors` (Attributes Set) Errors reported by AWS during image creation or management. (see [below for nested schema](#nestedatt--image_errors))
@@ -152,7 +152,5 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# Import uses destination image name and destination region.
-# Note: create-time-only attribute source_image_name should be set explicitly in configuration after import.
-terraform import awsappstream_copied_image.example "example-copied-image|us-east-1"
+terraform import awsappstream_copied_image.example "example-copied-image|us-east-1|example-source-image"
 ```

--- a/examples/resources/awsappstream_copied_image/import.sh
+++ b/examples/resources/awsappstream_copied_image/import.sh
@@ -1,3 +1,1 @@
-# Import uses destination image name and destination region.
-# Note: create-time-only attribute source_image_name should be set explicitly in configuration after import.
-terraform import awsappstream_copied_image.example "example-copied-image|us-east-1"
+terraform import awsappstream_copied_image.example "example-copied-image|us-east-1|example-source-image"

--- a/examples/resources/awsappstream_copied_image/resource.tf
+++ b/examples/resources/awsappstream_copied_image/resource.tf
@@ -1,9 +1,9 @@
 # minimal copied image
 resource "awsappstream_copied_image" "example" {
-  name               = "example-copied-image"
-  description        = "Copied image for development"
-  source_image_name  = "example-source-image"
-  destination_region = "us-east-1"
+  destination_image_name        = "example-copied-image"
+  destination_image_description = "Copied image for development"
+  destination_region            = "us-east-1"
+  source_image_name             = "example-source-image"
 
   tags = {
     Environment = "dev"

--- a/examples/resources/awsappstream_copied_image/resource_keep.tf
+++ b/examples/resources/awsappstream_copied_image/resource_keep.tf
@@ -1,9 +1,9 @@
 # copied image protected from destroy
 resource "awsappstream_copied_image" "keep" {
-  name               = "example-copied-image-keep"
-  description        = "Copied image retained for rollback"
-  source_image_name  = "example-source-image"
-  destination_region = "us-east-1"
+  destination_image_name        = "example-copied-image-keep"
+  destination_image_description = "Copied image retained for rollback"
+  destination_region            = "us-east-1"
+  source_image_name             = "example-source-image"
 
   # Prevent accidental image deletion via `terraform destroy` or replacement plans.
   lifecycle {

--- a/internal/resources/associate_app_block_builder_app_block/ids.go
+++ b/internal/resources/associate_app_block_builder_app_block/ids.go
@@ -13,7 +13,7 @@ func buildID(appBlockBuilderName, appBlockARN string) string {
 }
 
 func parseID(id string) (appBlockBuilderName, appBlockARN string, err error) {
-	parts := strings.SplitN(id, "|", 2)
+	parts := strings.Split(id, "|")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid associate app block builder app block ID format")
 	}

--- a/internal/resources/associate_application_entitlement/ids.go
+++ b/internal/resources/associate_application_entitlement/ids.go
@@ -13,7 +13,7 @@ func buildID(stackName, entitlementName, applicationIdentifier string) string {
 }
 
 func parseID(id string) (stackName, entitlementName, applicationIdentifier string, err error) {
-	parts := strings.SplitN(id, "|", 3)
+	parts := strings.Split(id, "|")
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return "", "", "", fmt.Errorf("invalid associate application entitlement ID format")
 	}

--- a/internal/resources/associate_application_fleet/ids.go
+++ b/internal/resources/associate_application_fleet/ids.go
@@ -13,7 +13,7 @@ func buildID(fleetName, applicationARN string) string {
 }
 
 func parseID(id string) (fleetName, applicationARN string, err error) {
-	parts := strings.SplitN(id, "|", 2)
+	parts := strings.Split(id, "|")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid associate application fleet ID format")
 	}

--- a/internal/resources/associate_fleet_stack/ids.go
+++ b/internal/resources/associate_fleet_stack/ids.go
@@ -13,7 +13,7 @@ func buildID(fleetName, stackName string) string {
 }
 
 func parseID(id string) (fleetName, stackName string, err error) {
-	parts := strings.SplitN(id, "|", 2)
+	parts := strings.Split(id, "|")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid associate fleet stack ID format")
 	}

--- a/internal/resources/associate_user_stack/ids.go
+++ b/internal/resources/associate_user_stack/ids.go
@@ -13,7 +13,7 @@ func buildID(stackName, authenticationType, userName string) string {
 }
 
 func parseID(id string) (stackName, authenticationType, userName string, err error) {
-	parts := strings.SplitN(id, "|", 3)
+	parts := strings.Split(id, "|")
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return "", "", "", fmt.Errorf("invalid associate user stack ID format")
 	}

--- a/internal/resources/copied_image/ids.go
+++ b/internal/resources/copied_image/ids.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 )
 
-func buildID(name, destinationRegion string) string {
-	return fmt.Sprintf("%s|%s", name, destinationRegion)
+func buildID(destinationImageName, destinationRegion, sourceImageName string) string {
+	return fmt.Sprintf("%s|%s|%s", destinationImageName, destinationRegion, sourceImageName)
 }
 
-func parseID(id string) (name, destinationRegion string, err error) {
-	parts := strings.SplitN(id, "|", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("invalid copied image ID format")
+func parseID(id string) (destinationImageName, destinationRegion, sourceImageName string, err error) {
+	parts := strings.Split(id, "|")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("invalid copied image import ID format")
 	}
 
-	return parts[0], parts[1], nil
+	return parts[0], parts[1], parts[2], nil
 }

--- a/internal/resources/copied_image/ids_test.go
+++ b/internal/resources/copied_image/ids_test.go
@@ -12,25 +12,31 @@ import (
 func TestBuildID(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "example-image|us-east-1", buildID("example-image", "us-east-1"))
+	require.Equal(
+		t,
+		"example-image|us-east-1|source-image",
+		buildID("example-image", "us-east-1", "source-image"),
+	)
 }
 
 func TestParseID(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                  string
-		id                    string
-		wantName              string
-		wantDestinationRegion string
-		wantErr               bool
+		name                     string
+		id                       string
+		wantDestinationImageName string
+		wantDestinationRegion    string
+		wantSourceImageName      string
+		wantErr                  bool
 	}{
 		{
-			name:                  "valid_id",
-			id:                    "example-image|us-east-1",
-			wantName:              "example-image",
-			wantDestinationRegion: "us-east-1",
-			wantErr:               false,
+			name:                     "valid_id",
+			id:                       "example-image|us-east-1|source-image",
+			wantDestinationImageName: "example-image",
+			wantDestinationRegion:    "us-east-1",
+			wantSourceImageName:      "source-image",
+			wantErr:                  false,
 		},
 		{
 			name:    "missing_separator",
@@ -44,12 +50,22 @@ func TestParseID(t *testing.T) {
 		},
 		{
 			name:    "empty_name",
-			id:      "|us-east-1",
+			id:      "|us-east-1|source-image",
 			wantErr: true,
 		},
 		{
 			name:    "empty_destination_region",
-			id:      "example-image|",
+			id:      "example-image||source-image",
+			wantErr: true,
+		},
+		{
+			name:    "empty_source_image_name",
+			id:      "example-image|us-east-1|",
+			wantErr: true,
+		},
+		{
+			name:    "too_many_parts",
+			id:      "example-image|us-east-1|source-image|extra",
 			wantErr: true,
 		},
 	}
@@ -58,7 +74,7 @@ func TestParseID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			name, destinationRegion, err := parseID(tt.id)
+			name, destinationRegion, sourceImageName, err := parseID(tt.id)
 
 			if tt.wantErr {
 				if err == nil {
@@ -71,10 +87,18 @@ func TestParseID(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if name != tt.wantName || destinationRegion != tt.wantDestinationRegion {
+			if name != tt.wantDestinationImageName ||
+				destinationRegion != tt.wantDestinationRegion ||
+				sourceImageName != tt.wantSourceImageName {
 				t.Fatalf(
-					"parseID(%q) = (%q, %q), want (%q, %q)",
-					tt.id, name, destinationRegion, tt.wantName, tt.wantDestinationRegion,
+					"parseID(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tt.id,
+					name,
+					destinationRegion,
+					sourceImageName,
+					tt.wantDestinationImageName,
+					tt.wantDestinationRegion,
+					tt.wantSourceImageName,
 				)
 			}
 		})

--- a/internal/resources/copied_image/resource.go
+++ b/internal/resources/copied_image/resource.go
@@ -73,21 +73,20 @@ func (r *resource) Configure(_ context.Context, req tfresource.ConfigureRequest,
 	r.tags = tags.NewTagManager(meta.Tagging, meta.DefaultTags)
 }
 
-// ImportState expects <destination_image_name>|<destination_region> and seeds
-// name, destination_region, and id from that identifier. source_image_name is a
-// create-time input and is not reconstructed during import because AWS read APIs
-// do not return the original copy source.
+// ImportState expects <destination_image_name>|<destination_region>|<source_image_name>
+// and seeds destination_image_name, destination_region, source_image_name, and id from that identifier.
 func (r *resource) ImportState(ctx context.Context, req tfresource.ImportStateRequest, resp *tfresource.ImportStateResponse) {
-	name, destinationRegion, err := parseID(req.ID)
+	destinationImageName, destinationRegion, sourceImageName, err := parseID(req.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			"Expected import identifier format: <destination_image_name>|<destination_region>",
+			"Expected import identifier format: <destination_image_name>|<destination_region>|<source_image_name>",
 		)
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("destination_image_name"), destinationImageName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("destination_region"), destinationRegion)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("source_image_name"), sourceImageName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), buildID(destinationImageName, destinationRegion, sourceImageName))...)
 }

--- a/internal/resources/copied_image/resource_create.go
+++ b/internal/resources/copied_image/resource_create.go
@@ -29,45 +29,34 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 		return
 	}
 
-	if plan.Name.IsNull() || plan.Name.IsUnknown() ||
+	if plan.DestinationImageName.IsNull() || plan.DestinationImageName.IsUnknown() ||
 		plan.DestinationRegion.IsNull() || plan.DestinationRegion.IsUnknown() ||
 		plan.SourceImageName.IsNull() || plan.SourceImageName.IsUnknown() {
 		resp.Diagnostics.AddError(
 			"Invalid Terraform Plan",
-			"Cannot create copied image because name, destination_region, and source_image_name must be known.",
+			"Cannot create copied image because destination_image_name, destination_region, and source_image_name must be known.",
 		)
 		return
 	}
 
-	name := plan.Name.ValueString()
+	destinationImageName := plan.DestinationImageName.ValueString()
 	destinationRegion := plan.DestinationRegion.ValueString()
 	sourceImageName := plan.SourceImageName.ValueString()
 
 	input := &awsappstream.CopyImageInput{
-		DestinationImageName:        aws.String(name),
+		DestinationImageName:        aws.String(destinationImageName),
 		DestinationRegion:           aws.String(destinationRegion),
 		SourceImageName:             aws.String(sourceImageName),
-		DestinationImageDescription: util.StringPointerOrNil(plan.Description),
+		DestinationImageDescription: util.StringPointerOrNil(plan.DestinationImageDescription),
 	}
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	err := util.RetryOn(
-		ctx,
-		func(ctx context.Context) error {
-			_, err := r.appstreamClient.CopyImage(ctx, input)
-			return err
-		},
-		util.WithTimeout(createRetryTimeout),
-		util.WithInitBackoff(createRetryInitBackoff),
-		util.WithMaxBackoff(createRetryMaxBackoff),
-		// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CopyImage.html
-		util.WithRetryOnFns(
-			util.IsResourceNotFoundException,
-		),
-	)
+	// see https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CopyImage.html
+	_, err := r.appstreamClient.CopyImage(ctx, input)
+
 	if err != nil {
 		if util.IsResourceAlreadyExists(err) {
 			resp.Diagnostics.AddError(
@@ -75,7 +64,7 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 				fmt.Sprintf(
 					"A copied image named %q already exists in %q. To manage it with Terraform, import it using:\n\n"+
 						"  terraform import <resource_address> %q",
-					name, destinationRegion, buildID(name, destinationRegion),
+					destinationImageName, destinationRegion, buildID(destinationImageName, destinationRegion, sourceImageName),
 				),
 			)
 			return
@@ -83,18 +72,18 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 
 		resp.Diagnostics.AddError(
 			"Error Creating AWS AppStream Copied Image",
-			fmt.Sprintf("Could not create copied image %q in %q: %v", name, destinationRegion, err),
+			fmt.Sprintf("Could not create copied image %q in %q: %v", destinationImageName, destinationRegion, err),
 		)
 		return
 	}
 
-	imageARN, err := r.ensureAvailable(ctx, name, destinationRegion)
+	imageARN, err := r.ensureAvailable(ctx, destinationImageName, destinationRegion)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating AWS AppStream Copied Image",
 			fmt.Sprintf(
 				"Copied image %q in %q did not reach AVAILABLE state in time: %v",
-				name, destinationRegion, err,
+				destinationImageName, destinationRegion, err,
 			),
 		)
 		return
@@ -105,7 +94,7 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 			fmt.Sprintf(
 				"Could not determine ARN for copied image %q in %q after it reached AVAILABLE state. "+
 					"The image cannot be tagged without an ARN.",
-				name, destinationRegion,
+				destinationImageName, destinationRegion,
 			),
 		)
 		return

--- a/internal/resources/copied_image/resource_delete.go
+++ b/internal/resources/copied_image/resource_delete.go
@@ -27,16 +27,17 @@ func (r *resource) Delete(ctx context.Context, req tfresource.DeleteRequest, res
 		return
 	}
 
-	if state.Name.IsNull() || state.Name.IsUnknown() ||
-		state.DestinationRegion.IsNull() || state.DestinationRegion.IsUnknown() {
+	if state.DestinationImageName.IsNull() || state.DestinationImageName.IsUnknown() ||
+		state.DestinationRegion.IsNull() || state.DestinationRegion.IsUnknown() ||
+		state.SourceImageName.IsNull() || state.SourceImageName.IsUnknown() {
 		resp.Diagnostics.AddError(
 			"Invalid Terraform State",
-			"Cannot delete copied image because name and destination_region must be known.",
+			"Cannot delete copied image because destination_image_name, destination_region, and source_image_name must be known.",
 		)
 		return
 	}
 
-	name := state.Name.ValueString()
+	name := state.DestinationImageName.ValueString()
 	destinationRegion := state.DestinationRegion.ValueString()
 
 	_, err := r.appstreamClient.DeleteImage(

--- a/internal/resources/copied_image/resource_diff_gen.go
+++ b/internal/resources/copied_image/resource_diff_gen.go
@@ -30,8 +30,8 @@ func (k changeKind) IsCleared() bool {
 
 type resourceDiff struct {
 	ID                          changeKind
-	Name                        changeKind
-	Description                 changeKind
+	DestinationImageName        changeKind
+	DestinationImageDescription changeKind
 	DestinationRegion           changeKind
 	SourceImageName             changeKind
 	Tags                        changeKind
@@ -65,7 +65,8 @@ func newResourceDiff(state resourceModel, plan resourceModel) resourceDiff {
 		AppstreamAgentVersion:       classifyChange(state.AppstreamAgentVersion, plan.AppstreamAgentVersion),
 		BaseImageARN:                classifyChange(state.BaseImageARN, plan.BaseImageARN),
 		CreatedTime:                 classifyChange(state.CreatedTime, plan.CreatedTime),
-		Description:                 classifyChange(state.Description, plan.Description),
+		DestinationImageDescription: classifyChange(state.DestinationImageDescription, plan.DestinationImageDescription),
+		DestinationImageName:        classifyChange(state.DestinationImageName, plan.DestinationImageName),
 		DestinationRegion:           classifyChange(state.DestinationRegion, plan.DestinationRegion),
 		DynamicAppProvidersEnabled:  classifyChange(state.DynamicAppProvidersEnabled, plan.DynamicAppProvidersEnabled),
 		ID:                          classifyChange(state.ID, plan.ID),
@@ -77,7 +78,6 @@ func newResourceDiff(state resourceModel, plan resourceModel) resourceDiff {
 		ImageType:                   classifyChange(state.ImageType, plan.ImageType),
 		LatestAppstreamAgentVersion: classifyChange(state.LatestAppstreamAgentVersion, plan.LatestAppstreamAgentVersion),
 		ManagedSoftwareIncluded:     classifyChange(state.ManagedSoftwareIncluded, plan.ManagedSoftwareIncluded),
-		Name:                        classifyChange(state.Name, plan.Name),
 		Platform:                    classifyChange(state.Platform, plan.Platform),
 		PublicBaseImageReleasedDate: classifyChange(state.PublicBaseImageReleasedDate, plan.PublicBaseImageReleasedDate),
 		SourceImageName:             classifyChange(state.SourceImageName, plan.SourceImageName),
@@ -104,7 +104,7 @@ func classifyChange(state attr.Value, plan attr.Value) changeKind {
 }
 
 func (d resourceDiff) HasRemoteChanges() bool {
-	return d.Name.IsChanged() || d.Description.IsChanged() || d.DestinationRegion.IsChanged() || d.SourceImageName.IsChanged()
+	return d.DestinationImageName.IsChanged() || d.DestinationImageDescription.IsChanged() || d.DestinationRegion.IsChanged() || d.SourceImageName.IsChanged()
 }
 
 func (d resourceDiff) RequiresTagApply() bool {

--- a/internal/resources/copied_image/resource_model_gen.go
+++ b/internal/resources/copied_image/resource_model_gen.go
@@ -5,17 +5,18 @@ package copied_image
 import types "github.com/hashicorp/terraform-plugin-framework/types"
 
 type resourceModel struct {
-	// A synthetic identifier for the copied image, composed of the name and destination region. This value is
-	// managed by the provider and cannot be set manually.
+	// A synthetic identifier for the copied image, composed of the destination image name, destination region, and
+	// source image name. This value is managed by the provider and cannot be set manually.
 	ID types.String `tfsdk:"id"`
 	// A unique destination name for the copied image. Changing this value forces the copied image to be replaced.
-	Name types.String `tfsdk:"name"`
+	DestinationImageName types.String `tfsdk:"destination_image_name"`
 	// A description for the copied image. Changing this value forces the copied image to be replaced.
-	Description types.String `tfsdk:"description"`
+	DestinationImageDescription types.String `tfsdk:"destination_image_description"`
 	// The AWS region where the copied image is created. Changing this value forces the copied image to be replaced.
 	DestinationRegion types.String `tfsdk:"destination_region"`
 	// The name of the source image used for the copy operation. Changing this value forces the copied image to be
-	// replaced. After import, this create-time input must be set explicitly in configuration.
+	// replaced. AWS read APIs do not reliably return this value, so import requires it as the third segment of the
+	// import identifier.
 	SourceImageName types.String `tfsdk:"source_image_name"`
 	// A map of tags assigned to the copied image.
 	Tags types.Map `tfsdk:"tags"`

--- a/internal/resources/copied_image/resource_read.go
+++ b/internal/resources/copied_image/resource_read.go
@@ -32,11 +32,12 @@ func (r *resource) Read(ctx context.Context, req tfresource.ReadRequest, resp *t
 		return
 	}
 
-	if state.Name.IsNull() || state.Name.IsUnknown() ||
-		state.DestinationRegion.IsNull() || state.DestinationRegion.IsUnknown() {
+	if state.DestinationImageName.IsNull() || state.DestinationImageName.IsUnknown() ||
+		state.DestinationRegion.IsNull() || state.DestinationRegion.IsUnknown() ||
+		state.SourceImageName.IsNull() || state.SourceImageName.IsUnknown() {
 		resp.Diagnostics.AddError(
 			"Invalid Terraform State",
-			"Required attributes name and destination_region are missing from state. "+
+			"Required attributes destination_image_name, destination_region, and source_image_name are missing from state. "+
 				"This can happen after an incomplete import or a prior provider bug. Re-import or recreate the resource.",
 		)
 		return
@@ -62,13 +63,14 @@ func (r *resource) Read(ctx context.Context, req tfresource.ReadRequest, resp *t
 func (r *resource) readCopiedImage(ctx context.Context, prior resourceModel) (*resourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	name := prior.Name.ValueString()
+	destinationImageName := prior.DestinationImageName.ValueString()
 	destinationRegion := prior.DestinationRegion.ValueString()
+	sourceImageName := prior.SourceImageName.ValueString()
 
 	out, err := r.appstreamClient.DescribeImages(
 		ctx,
 		&awsappstream.DescribeImagesInput{
-			Names: []string{name},
+			Names: []string{destinationImageName},
 		},
 		func(o *awsappstream.Options) {
 			o.Region = destinationRegion
@@ -84,7 +86,7 @@ func (r *resource) readCopiedImage(ctx context.Context, prior resourceModel) (*r
 		}
 		diags.AddError(
 			"Error Reading AWS AppStream Copied Image",
-			fmt.Sprintf("Could not read copied image %q: %v", name, err),
+			fmt.Sprintf("Could not read copied image %q: %v", destinationImageName, err),
 		)
 		return nil, diags
 	}
@@ -98,14 +100,12 @@ func (r *resource) readCopiedImage(ctx context.Context, prior resourceModel) (*r
 		return nil, diags
 	}
 
-	sourceImageName := util.ARNResourceSuffixOrNil(image.BaseImageArn, "appstream", "image/")
-
 	state := &resourceModel{
-		ID:                          types.StringValue(buildID(name, destinationRegion)),
-		Name:                        types.StringValue(aws.ToString(image.Name)),
-		Description:                 util.StringOrNull(image.Description),
+		ID:                          types.StringValue(buildID(destinationImageName, destinationRegion, sourceImageName)),
+		DestinationImageName:        types.StringValue(aws.ToString(image.Name)),
+		DestinationImageDescription: util.StringOrNull(image.Description),
 		DestinationRegion:           prior.DestinationRegion,
-		SourceImageName:             util.FlattenStateOwnedString(prior.SourceImageName, sourceImageName),
+		SourceImageName:             prior.SourceImageName,
 		Tags:                        types.MapNull(types.StringType),
 		TagsAll:                     types.MapNull(types.StringType),
 		ARN:                         util.StringOrNull(image.Arn),

--- a/internal/resources/copied_image/resource_schema.go
+++ b/internal/resources/copied_image/resource_schema.go
@@ -26,20 +26,19 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 			"`CopyImage` is invoked using the provider-configured region (source region), while `destination_region` " +
 			"controls where the copied image is created. " +
 			"Copied images are immutable artifacts and are typically replaced when copy input settings change. " +
-			"AppStream `CopyImage` does not copy tags, so tags are managed separately by the provider. " +
-			"After `terraform import`, configure create-time-only attribute `source_image_name` " +
-			"explicitly because the provider does not reconstruct this value from imported state.",
+			"AppStream `CopyImage` does not copy tags, so tags are managed separately by the provider.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Identifier of the AppStream Copied Image.",
-				MarkdownDescription: "A synthetic identifier for the copied image, composed of the name and destination region. " +
+				MarkdownDescription: "A synthetic identifier for the copied image, composed of the " +
+					"destination image name, destination region, and source image name. " +
 					"This value is managed by the provider and cannot be set manually.",
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"name": schema.StringAttribute{
+			"destination_image_name": schema.StringAttribute{
 				Description: "Name of the AppStream Copied Image.",
 				MarkdownDescription: "A unique destination name for the copied image. " +
 					"Changing this value forces the copied image to be replaced.",
@@ -54,7 +53,7 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 					),
 				},
 			},
-			"description": schema.StringAttribute{
+			"destination_image_description": schema.StringAttribute{
 				Description: "Description of the AppStream Copied Image.",
 				MarkdownDescription: "A description for the copied image. " +
 					"Changing this value forces the copied image to be replaced.",
@@ -82,7 +81,8 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 				Description: "Source AppStream image name.",
 				MarkdownDescription: "The name of the source image used for the copy operation. " +
 					"Changing this value forces the copied image to be replaced. " +
-					"After import, this create-time input must be set explicitly in configuration.",
+					"AWS read APIs do not reliably return this value, so import requires it as the third segment " +
+					"of the import identifier.",
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/resources/copied_image/retry.go
+++ b/internal/resources/copied_image/retry.go
@@ -6,10 +6,6 @@ package copied_image
 import "time"
 
 const (
-	createRetryTimeout     = 10 * time.Minute
-	createRetryInitBackoff = 5 * time.Second
-	createRetryMaxBackoff  = 30 * time.Second
-
 	waitAvailableRetryTimeout     = 1 * time.Hour
 	waitAvailableRetryInitBackoff = 30 * time.Second
 	waitAvailableRetryMaxBackoff  = 1 * time.Minute

--- a/internal/resources/entitlement/ids.go
+++ b/internal/resources/entitlement/ids.go
@@ -13,7 +13,7 @@ func buildID(stackName, name string) string {
 }
 
 func parseID(id string) (stackName, name string, err error) {
-	parts := strings.SplitN(id, "|", 2)
+	parts := strings.Split(id, "|")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid entitlement ID format")
 	}

--- a/internal/resources/image_permission/ids.go
+++ b/internal/resources/image_permission/ids.go
@@ -13,7 +13,7 @@ func buildID(name, sharedAccountID string) string {
 }
 
 func parseID(id string) (name, sharedAccountID string, err error) {
-	parts := strings.SplitN(id, "|", 2)
+	parts := strings.Split(id, "|")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid image permission ID format")
 	}

--- a/internal/resources/user/ids.go
+++ b/internal/resources/user/ids.go
@@ -13,7 +13,7 @@ func buildID(authenticationType, userName string) string {
 }
 
 func parseID(id string) (authenticationType, userName string, err error) {
-	parts := strings.SplitN(id, "|", 2)
+	parts := strings.Split(id, "|")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid user ID format")
 	}


### PR DESCRIPTION
## Related Issue

Fixes: #89 

Commit style:
- Commits in this PR must comply with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (`type(scope): description`).

## Description

- fix id validation for import
- rename `awsappstream_copied_image` properties
- `source_image_name` is required for import of `awsappstream_copied_image`
- `source_image_name` is set from prior state

## Release Impact

Select one:
- [x] Hotfix (patch)
- [ ] Minor change
- [ ] Major/breaking change
- [ ] No provider behavior change (docs/CI/repo-only changes)

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

- `No changes to security controls in this pull request.`
