### PR TITLE
fix: awsappstream_imported_image import

### DIFF
--- a/docs/resources/imported_image.md
+++ b/docs/resources/imported_image.md
@@ -3,12 +3,12 @@
 page_title: "awsappstream_imported_image Resource - AWS AppStream"
 subcategory: ""
 description: |-
-  Manages an AppStream imported image created from an EC2 AMI. Imported images are immutable artifacts and are typically replaced when input settings change. After terraform import, configure create-time-only attributes explicitly (iam_role_arn, source_ami_id, agent_software_version, runtime_validation_config, app_catalog_config) because AWS DescribeImages does not return these original input values.
+  Manages an AppStream imported image created from an EC2 AMI. Imported images are immutable artifacts and are typically replaced when input settings change. After terraform import, configure create-time-only attributes explicitly (agent_software_version, runtime_validation_config, app_catalog_config) because AWS DescribeImages does not return these original input values.
 ---
 
 # awsappstream_imported_image (Resource)
 
-Manages an AppStream imported image created from an EC2 AMI. Imported images are immutable artifacts and are typically replaced when input settings change. After `terraform import`, configure create-time-only attributes explicitly (`iam_role_arn`, `source_ami_id`, `agent_software_version`, `runtime_validation_config`, `app_catalog_config`) because AWS `DescribeImages` does not return these original input values.
+Manages an AppStream imported image created from an EC2 AMI. Imported images are immutable artifacts and are typically replaced when input settings change. After `terraform import`, configure create-time-only attributes explicitly (`agent_software_version`, `runtime_validation_config`, `app_catalog_config`) because AWS `DescribeImages` does not return these original input values.
 
 ## Example Usage
 
@@ -89,9 +89,9 @@ resource "awsappstream_imported_image" "keep" {
 
 ### Required
 
-- `iam_role_arn` (String) The ARN of the IAM role that allows AppStream to access and validate the source AMI. Changing this value forces the imported image to be replaced. This create-time input is not returned by `DescribeImages`, so after import it must be set explicitly in configuration.
+- `iam_role_arn` (String) The ARN of the IAM role that allows AppStream to access and validate the source AMI. Changing this value forces the imported image to be replaced.
 - `name` (String) A unique name for the imported image. Changing this value forces the imported image to be replaced.
-- `source_ami_id` (String) The EC2 AMI ID to import into AppStream. Changing this value forces the imported image to be replaced. This create-time input is not returned by `DescribeImages`, so after import it must be set explicitly in configuration.
+- `source_ami_id` (String) The EC2 AMI ID to import into AppStream. Changing this value forces the imported image to be replaced.
 
 ### Optional
 
@@ -110,7 +110,7 @@ resource "awsappstream_imported_image" "keep" {
 - `base_image_arn` (String) The ARN of the image from which this image was created.
 - `created_time` (String) The timestamp when the AppStream imported image was created, in RFC 3339 format.
 - `dynamic_app_providers_enabled` (String) Indicates whether dynamic app providers are enabled.
-- `id` (String) A synthetic identifier for the imported image, equal to the image name. This value is managed by the provider and cannot be set manually.
+- `id` (String) A synthetic identifier for the imported image, composed of image name, IAM role ARN, and source AMI ID. This value is managed by the provider and cannot be set manually.
 - `image_builder_name` (String) The name of the image builder used to create the image, if applicable.
 - `image_builder_supported` (Boolean) Whether an AppStream image builder can be launched from this imported image.
 - `image_errors` (Attributes Set) Errors reported by AWS during image creation or management. (see [below for nested schema](#nestedatt--image_errors))
@@ -217,9 +217,8 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# Import uses image name only.
-# Note: create-time-only attributes (iam_role_arn, source_ami_id, agent_software_version,
-# runtime_validation_config, app_catalog_config) are not returned by DescribeImages and
-# should be set explicitly in configuration after import.
-terraform import awsappstream_imported_image.example "example-image"
+# Import uses: name|iam_role_arn|source_ami_id.
+# Note: create-time-only attributes (agent_software_version, runtime_validation_config, app_catalog_config)
+# are not returned by DescribeImages and should be set explicitly in configuration after import.
+terraform import awsappstream_imported_image.example "example-image|arn:aws:iam::123456789012:role/appstream-import|ami-0abc1234def567890"
 ```

--- a/examples/resources/awsappstream_imported_image/import.sh
+++ b/examples/resources/awsappstream_imported_image/import.sh
@@ -1,5 +1,4 @@
-# Import uses image name only.
-# Note: create-time-only attributes (iam_role_arn, source_ami_id, agent_software_version,
-# runtime_validation_config, app_catalog_config) are not returned by DescribeImages and
-# should be set explicitly in configuration after import.
-terraform import awsappstream_imported_image.example "example-image"
+# Import uses: name|iam_role_arn|source_ami_id.
+# Note: create-time-only attributes (agent_software_version, runtime_validation_config, app_catalog_config)
+# are not returned by DescribeImages and should be set explicitly in configuration after import.
+terraform import awsappstream_imported_image.example "example-image|arn:aws:iam::123456789012:role/appstream-import|ami-0abc1234def567890"

--- a/internal/resources/imported_image/ids.go
+++ b/internal/resources/imported_image/ids.go
@@ -1,0 +1,22 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package imported_image
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildID(name, iamRoleARN, sourceAmiID string) string {
+	return fmt.Sprintf("%s|%s|%s", name, iamRoleARN, sourceAmiID)
+}
+
+func parseID(id string) (name, iamRoleARN, sourceAmiID string, err error) {
+	parts := strings.Split(id, "|")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("invalid imported image import ID format")
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}

--- a/internal/resources/imported_image/ids_test.go
+++ b/internal/resources/imported_image/ids_test.go
@@ -1,0 +1,93 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package imported_image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildID(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		"example-image|arn:aws:iam::123456789012:role/example|ami-0abc1234def567890",
+		buildID(
+			"example-image",
+			"arn:aws:iam::123456789012:role/example",
+			"ami-0abc1234def567890",
+		),
+	)
+}
+
+func TestParseID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		id             string
+		wantName       string
+		wantIAMRoleARN string
+		wantSourceAmi  string
+		wantErr        bool
+	}{
+		{
+			name:           "valid_id",
+			id:             "example-image|arn:aws:iam::123456789012:role/example|ami-0abc1234def567890",
+			wantName:       "example-image",
+			wantIAMRoleARN: "arn:aws:iam::123456789012:role/example",
+			wantSourceAmi:  "ami-0abc1234def567890",
+		},
+		{
+			name:    "missing_separator",
+			id:      "example-image-arn:aws:iam::123456789012:role/example-ami-0abc1234def567890",
+			wantErr: true,
+		},
+		{
+			name:    "empty_string",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name:    "empty_name",
+			id:      "|arn:aws:iam::123456789012:role/example|ami-0abc1234def567890",
+			wantErr: true,
+		},
+		{
+			name:    "empty_iam_role_arn",
+			id:      "example-image||ami-0abc1234def567890",
+			wantErr: true,
+		},
+		{
+			name:    "empty_source_ami_id",
+			id:      "example-image|arn:aws:iam::123456789012:role/example|",
+			wantErr: true,
+		},
+		{
+			name:    "too_many_parts",
+			id:      "example-image|arn:aws:iam::123456789012:role/example|ami-0abc1234def567890|extra",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, iamRoleARN, sourceAmiID, err := parseID(tt.id)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantName, name)
+			require.Equal(t, tt.wantIAMRoleARN, iamRoleARN)
+			require.Equal(t, tt.wantSourceAmi, sourceAmiID)
+		})
+	}
+}

--- a/internal/resources/imported_image/resource.go
+++ b/internal/resources/imported_image/resource.go
@@ -73,16 +73,20 @@ func (r *resource) Configure(_ context.Context, req tfresource.ConfigureRequest,
 	r.tags = tags.NewTagManager(meta.Tagging, meta.DefaultTags)
 }
 
-// ImportState expects <image_name> and seeds both name and id from that identifier.
+// ImportState expects <name>|<iam_role_arn>|<source_ami_id>
+// and seeds name, iam_role_arn, source_ami_id, and id from that identifier.
 func (r *resource) ImportState(ctx context.Context, req tfresource.ImportStateRequest, resp *tfresource.ImportStateResponse) {
-	if req.ID == "" {
+	name, iamRoleARN, sourceAmiID, err := parseID(req.ID)
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			"Expected import identifier format: <image_name>",
+			"Expected import identifier format: <name>|<iam_role_arn>|<source_ami_id>",
 		)
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("iam_role_arn"), iamRoleARN)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("source_ami_id"), sourceAmiID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }

--- a/internal/resources/imported_image/resource_create.go
+++ b/internal/resources/imported_image/resource_create.go
@@ -38,15 +38,16 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 	}
 
 	name := plan.Name.ValueString()
+	iamRoleARN := plan.IAMRoleARN.ValueString()
+	sourceAmiID := plan.SourceAmiID.ValueString()
 
 	input := &awsappstream.CreateImportedImageInput{
-		Name:        util.StringPointerOrNil(plan.Name),
-		IamRoleArn:  util.StringPointerOrNil(plan.IAMRoleARN),
-		SourceAmiId: util.StringPointerOrNil(plan.SourceAmiID),
+		Name:        aws.String(name),
+		IamRoleArn:  aws.String(iamRoleARN),
+		SourceAmiId: aws.String(sourceAmiID),
+		DisplayName: util.StringPointerOrNil(plan.DisplayName),
+		Description: util.StringPointerOrNil(plan.Description),
 	}
-
-	input.DisplayName = util.StringPointerOrNil(plan.DisplayName)
-	input.Description = util.StringPointerOrNil(plan.Description)
 
 	if !plan.AgentSoftwareVersion.IsNull() && !plan.AgentSoftwareVersion.IsUnknown() {
 		input.AgentSoftwareVersion = awstypes.AgentSoftwareVersion(plan.AgentSoftwareVersion.ValueString())
@@ -85,7 +86,7 @@ func (r *resource) Create(ctx context.Context, req tfresource.CreateRequest, res
 				fmt.Sprintf(
 					"An imported image named %q already exists. To manage it with Terraform, import it using:\n\n"+
 						"  terraform import <resource_address> %q",
-					name, name,
+					name, buildID(name, iamRoleARN, sourceAmiID),
 				),
 			)
 			return

--- a/internal/resources/imported_image/resource_model_gen.go
+++ b/internal/resources/imported_image/resource_model_gen.go
@@ -5,18 +5,15 @@ package imported_image
 import types "github.com/hashicorp/terraform-plugin-framework/types"
 
 type resourceModel struct {
-	// A synthetic identifier for the imported image, equal to the image name. This value is managed by the provider
-	// and cannot be set manually.
+	// A synthetic identifier for the imported image, composed of image name, IAM role ARN, and source AMI ID. This
+	// value is managed by the provider and cannot be set manually.
 	ID types.String `tfsdk:"id"`
 	// A unique name for the imported image. Changing this value forces the imported image to be replaced.
 	Name types.String `tfsdk:"name"`
 	// The ARN of the IAM role that allows AppStream to access and validate the source AMI. Changing this value
-	// forces the imported image to be replaced. This create-time input is not returned by `DescribeImages`, so after
-	// import it must be set explicitly in configuration.
+	// forces the imported image to be replaced.
 	IAMRoleARN types.String `tfsdk:"iam_role_arn"`
-	// The EC2 AMI ID to import into AppStream. Changing this value forces the imported image to be replaced. This
-	// create-time input is not returned by `DescribeImages`, so after import it must be set explicitly in
-	// configuration.
+	// The EC2 AMI ID to import into AppStream. Changing this value forces the imported image to be replaced.
 	SourceAmiID types.String `tfsdk:"source_ami_id"`
 	// The AppStream agent software version used for the imported image. Valid values are `CURRENT_LATEST` and
 	// `ALWAYS_LATEST`. Changing this value forces the imported image to be replaced. This create-time input is not

--- a/internal/resources/imported_image/resource_read.go
+++ b/internal/resources/imported_image/resource_read.go
@@ -90,7 +90,9 @@ func (r *resource) readImportedImage(ctx context.Context, prior resourceModel) (
 	}
 
 	state := &resourceModel{
-		ID:                          types.StringValue(aws.ToString(image.Name)),
+		ID: types.StringValue(
+			buildID(aws.ToString(image.Name), prior.IAMRoleARN.ValueString(), prior.SourceAmiID.ValueString()),
+		),
 		Name:                        types.StringValue(aws.ToString(image.Name)),
 		IAMRoleARN:                  prior.IAMRoleARN,
 		SourceAmiID:                 prior.SourceAmiID,

--- a/internal/resources/imported_image/resource_schema.go
+++ b/internal/resources/imported_image/resource_schema.go
@@ -29,13 +29,13 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 		Description: "Manage an AWS AppStream Imported Image",
 		MarkdownDescription: "Manages an AppStream imported image created from an EC2 AMI. " +
 			"Imported images are immutable artifacts and are typically replaced when input settings change. " +
-			"After `terraform import`, configure create-time-only attributes explicitly (`iam_role_arn`, `source_ami_id`, " +
-			"`agent_software_version`, `runtime_validation_config`, `app_catalog_config`) because AWS `DescribeImages` " +
+			"After `terraform import`, configure create-time-only attributes explicitly " +
+			"(`agent_software_version`, `runtime_validation_config`, `app_catalog_config`) because AWS `DescribeImages` " +
 			"does not return these original input values.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Identifier of the AppStream Imported Image.",
-				MarkdownDescription: "A synthetic identifier for the imported image, equal to the image name. " +
+				MarkdownDescription: "A synthetic identifier for the imported image, composed of image name, IAM role ARN, and source AMI ID. " +
 					"This value is managed by the provider and cannot be set manually.",
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -60,8 +60,7 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 			"iam_role_arn": schema.StringAttribute{
 				Description: "IAM role ARN for the Imported Image.",
 				MarkdownDescription: "The ARN of the IAM role that allows AppStream to access and validate the source AMI. " +
-					"Changing this value forces the imported image to be replaced. " +
-					"This create-time input is not returned by `DescribeImages`, so after import it must be set explicitly in configuration.",
+					"Changing this value forces the imported image to be replaced.",
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -73,8 +72,7 @@ func (r *resource) Schema(_ context.Context, _ tfresource.SchemaRequest, resp *t
 			"source_ami_id": schema.StringAttribute{
 				Description: "Source EC2 AMI ID for the Imported Image.",
 				MarkdownDescription: "The EC2 AMI ID to import into AppStream. " +
-					"Changing this value forces the imported image to be replaced. " +
-					"This create-time input is not returned by `DescribeImages`, so after import it must be set explicitly in configuration.",
+					"Changing this value forces the imported image to be replaced.",
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
## Related Issue

Fixes: None

Commit style:
- Commits in this PR must comply with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (`type(scope): description`).

## Description

This PR fixes `awsappstream_imported_image` import identity handling and aligns ID generation across import/create/read.

Key updates:
- Added imported image ID helpers:
  - `internal/resources/imported_image/ids.go`
  - `internal/resources/imported_image/ids_test.go`
- Switched imported image ID format to:
  - `<name>|<iam_role_arn>|<source_ami_id>`
- Updated import behavior in `ImportState`:
  - Parse and validate the 3-part ID
  - Set `name`, `iam_role_arn`, `source_ami_id`, and `id` from import input
- Updated read path to rebuild a stable composite ID from state-owned inputs:
  - `internal/resources/imported_image/resource_read.go`
- Updated schema/model descriptions for `id` and import semantics:
  - `internal/resources/imported_image/resource_schema.go`
  - `internal/resources/imported_image/resource_model_gen.go`
- Updated duplicate-resource import hint in create flow to the new ID format:
  - `internal/resources/imported_image/resource_create.go`
- Updated import examples and generated docs:
  - `examples/resources/awsappstream_imported_image/import.sh`
  - `docs/resources/imported_image.md`

Design choice:
- Use a composite synthetic ID (`name|iam_role_arn|source_ami_id`) so import and steady-state reads preserve required create-time identity inputs that are not fully recoverable from `DescribeImages` alone.

## Release Impact

Select one:
- [x] Hotfix (patch)
- [ ] Minor change
- [ ] Major/breaking change
- [ ] No provider behavior change (docs/CI/repo-only changes)

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

- `No changes to security controls in this pull request.`
