### PR TITLE
feat: Add optional states filter to awsappstream_image data source

### DIFF
--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -51,6 +51,7 @@ data "awsappstream_image" "latest_private" {
 - `most_recent` (Boolean) Whether the most recent AppStream image is returned when multiple images match the selection criteria. If set to `false` and multiple images match, the data source will return an error.
 - `name` (String) The name of the AppStream image. Cannot be used together with `arn` or `name_regex`. If multiple images with the same name exist, the data source will return an error.
 - `name_regex` (String) A regular expression used to match AppStream image names. Uses Go regular expression syntax. Cannot be used together with `arn` or `name`. If the expression matches multiple images, the data source will return an error.
+- `states` (Set of String) The image states used to filter AppStream images.
 - `visibility` (String) The image visibility. Valid values are `PUBLIC`, `PRIVATE`, or `SHARED`.
 
 ### Read-Only

--- a/internal/resources/image/data_source_model_gen.go
+++ b/internal/resources/image/data_source_model_gen.go
@@ -18,6 +18,8 @@ type dataSourceModel struct {
 	NameRegex types.String `tfsdk:"name_regex"`
 	// The image visibility. Valid values are `PUBLIC`, `PRIVATE`, or `SHARED`.
 	Visibility types.String `tfsdk:"visibility"`
+	// The image states used to filter AppStream images.
+	States types.Set `tfsdk:"states"`
 	// Whether the most recent AppStream image is returned when multiple images match the selection criteria. If set
 	// to `false` and multiple images match, the data source will return an error.
 	MostRecent types.Bool `tfsdk:"most_recent"`

--- a/internal/resources/image/data_source_read.go
+++ b/internal/resources/image/data_source_read.go
@@ -13,6 +13,7 @@ import (
 	awsappstream "github.com/aws/aws-sdk-go-v2/service/appstream"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/st3ffn/terraform-provider-aws-appstream/internal/util"
 )
@@ -74,7 +75,10 @@ func (ds *dataSource) Read(ctx context.Context, req datasource.ReadRequest, resp
 		ID:                          types.StringValue(aws.ToString(selected.Arn)),
 		ARN:                         types.StringValue(aws.ToString(selected.Arn)),
 		Name:                        types.StringValue(aws.ToString(selected.Name)),
+		NameRegex:                   config.NameRegex,
 		Visibility:                  types.StringValue(string(selected.Visibility)),
+		States:                      config.States,
+		MostRecent:                  config.MostRecent,
 		BaseImageARN:                util.StringOrNull(selected.BaseImageArn),
 		DisplayName:                 util.StringOrNull(selected.DisplayName),
 		State:                       types.StringValue(string(selected.State)),
@@ -98,6 +102,10 @@ func (ds *dataSource) Read(ctx context.Context, req datasource.ReadRequest, resp
 		Tags:                        types.MapNull(types.StringType),
 	}
 
+	if state.States.IsNull() && state.States.Type(ctx) == nil {
+		state.States = types.SetNull(types.StringType)
+	}
+
 	if !state.ARN.IsNull() && selected.Visibility != awstypes.VisibilityTypePublic {
 		tags, diags := ds.tags.ReadAll(ctx, state.ARN.ValueString())
 		resp.Diagnostics.Append(diags...)
@@ -113,8 +121,9 @@ func (ds *dataSource) Read(ctx context.Context, req datasource.ReadRequest, resp
 
 func (ds *dataSource) listImages(ctx context.Context, config *dataSourceModel) ([]awstypes.Image, error) {
 	var (
-		arns  []string
-		names []string
+		arns   []string
+		names  []string
+		states map[awstypes.ImageState]struct{}
 	)
 
 	if !config.ARN.IsNull() && !config.ARN.IsUnknown() {
@@ -132,6 +141,12 @@ func (ds *dataSource) listImages(ctx context.Context, config *dataSourceModel) (
 			return nil, err
 		}
 		regex = r
+	}
+
+	var diags diag.Diagnostics
+	states = expandStates(ctx, config.States, &diags)
+	if diags.HasError() {
+		return nil, fmt.Errorf("expanding states filter: %v", diags)
 	}
 
 	var out []awstypes.Image
@@ -155,6 +170,11 @@ func (ds *dataSource) listImages(ctx context.Context, config *dataSourceModel) (
 		for _, image := range resp.Images {
 			if regex != nil {
 				if image.Name == nil || !regex.MatchString(*image.Name) {
+					continue
+				}
+			}
+			if states != nil {
+				if _, ok := states[image.State]; !ok {
 					continue
 				}
 			}

--- a/internal/resources/image/data_source_schema.go
+++ b/internal/resources/image/data_source_schema.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -72,6 +73,19 @@ func (ds *dataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						util.AWSEnumToSlice(awstypes.VisibilityType.Values)...,
+					),
+				},
+			},
+			"states": schema.SetAttribute{
+				Description:         "States of the AppStream Image.",
+				MarkdownDescription: "The image states used to filter AppStream images.",
+				Optional:            true,
+				ElementType:         types.StringType,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						stringvalidator.OneOf(
+							util.AWSEnumToSlice(awstypes.ImageState.Values)...,
+						),
 					),
 				},
 			},

--- a/internal/resources/image/data_source_test.go
+++ b/internal/resources/image/data_source_test.go
@@ -26,6 +26,15 @@ data "awsappstream_image" "test" {
 `
 }
 
+func testAccImageDataSourceByARNAndState(region string) string {
+	return testhelpers.TestAccProviderBasicConfig() + `
+data "awsappstream_image" "test" {
+  arn = "` + testAccPublicImageARN(region) + `"
+  states = ["AVAILABLE"]
+}
+`
+}
+
 func TestAccImageDataSource_basicByARN(t *testing.T) {
 	testEnv := testhelpers.LoadAccTestEnv(t)
 
@@ -41,6 +50,34 @@ func TestAccImageDataSource_basicByARN(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "created_time"),
 					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "platform"),
 					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "state"),
+					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "image_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageDataSource_byARNAndAvailableState(t *testing.T) {
+	testEnv := testhelpers.LoadAccTestEnv(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageDataSourceByARNAndState(testEnv.Region),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.awsappstream_image.test", "arn", testAccPublicImageARN(testEnv.Region)),
+					resource.TestCheckResourceAttr("data.awsappstream_image.test", "name", testAccPublicImageName),
+					resource.TestCheckResourceAttr("data.awsappstream_image.test", "visibility", "PUBLIC"),
+					resource.TestCheckResourceAttr("data.awsappstream_image.test", "state", "AVAILABLE"),
+					resource.TestCheckResourceAttr("data.awsappstream_image.test", "states.#", "1"),
+					resource.TestCheckTypeSetElemAttr(
+						"data.awsappstream_image.test",
+						"states.*",
+						"AVAILABLE",
+					),
+					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "created_time"),
+					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "platform"),
 					resource.TestCheckResourceAttrSet("data.awsappstream_image.test", "image_type"),
 				),
 			},

--- a/internal/resources/image/expand.go
+++ b/internal/resources/image/expand.go
@@ -1,0 +1,35 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package image
+
+import (
+	"context"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/st3ffn/terraform-provider-aws-appstream/internal/util"
+)
+
+func expandStates(ctx context.Context, set types.Set, diags *diag.Diagnostics) map[awstypes.ImageState]struct{} {
+	if set.IsNull() || set.IsUnknown() {
+		return nil
+	}
+
+	values := util.ExpandStringSetOrNil(ctx, set, diags)
+	if diags.HasError() {
+		return nil
+	}
+
+	if len(values) == 0 {
+		return nil
+	}
+
+	out := make(map[awstypes.ImageState]struct{}, len(values))
+	for _, v := range values {
+		out[awstypes.ImageState(v)] = struct{}{}
+	}
+
+	return out
+}

--- a/internal/resources/image/expand_test.go
+++ b/internal/resources/image/expand_test.go
@@ -1,0 +1,103 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package image
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestExpandStates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		input     types.Set
+		want      map[awstypes.ImageState]struct{}
+		wantError bool
+	}{
+		{
+			name:  "null_set_returns_nil",
+			input: types.SetNull(types.StringType),
+			want:  nil,
+		},
+		{
+			name:  "unknown_set_returns_nil",
+			input: types.SetUnknown(types.StringType),
+			want:  nil,
+		},
+		{
+			name:  "empty_set_returns_nil",
+			input: types.SetValueMust(types.StringType, []attr.Value{}),
+			want:  nil,
+		},
+		{
+			name: "single_value_returns_map",
+			input: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("AVAILABLE")},
+			),
+			want: map[awstypes.ImageState]struct{}{
+				awstypes.ImageStateAvailable: {},
+			},
+		},
+		{
+			name: "multiple_values_returns_map",
+			input: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{
+					types.StringValue("PENDING"),
+					types.StringValue("VALIDATING"),
+				},
+			),
+			want: map[awstypes.ImageState]struct{}{
+				awstypes.ImageStatePending:    {},
+				awstypes.ImageStateValidating: {},
+			},
+		},
+		{
+			name: "invalid_value_produces_diagnostics",
+			input: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{
+					types.StringUnknown(),
+				},
+			),
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags diag.Diagnostics
+
+			got := expandStates(ctx, tt.input, &diags)
+
+			if tt.wantError {
+				if !diags.HasError() {
+					t.Fatalf("expected diagnostics error, got none")
+				}
+				return
+			}
+
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("expandStates() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related Issue

Fixes: #133 

Commit style:
- Commits in this PR must comply with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (`type(scope): description`).

## Description

This PR adds an optional `states` filter to the `awsappstream_image` data source so users can restrict image selection to one or more AppStream image lifecycle states.

Key updates:
- Added an optional `states` schema attribute to `awsappstream_image`.
- Implemented client-side filtering of AppStream images by state in the data source read path.
- Added a dedicated `expandStates` helper in `expand.go` to convert the Terraform set into AppStream image state values.
- Preserved the configured `states` value in data source state using the correct typed set handling.
- Added unit coverage for `expandStates`.
- Added acceptance coverage for filtering with `states = ["AVAILABLE"]`.

Design choice:
The filter is optional and applied client-side after `DescribeImages`. AWS AppStream does not provide a server-side state filter for `DescribeImages`, so client-side filtering is the safest way to add this capability without changing existing behavior. Leaving the filter optional preserves backward compatibility for users who currently rely on matching images in any state.

## Release Impact

Select one:
- [x] Minor change
- [ ] Hotfix (patch)
- [ ] Major/breaking change
- [ ] No provider behavior change (docs/CI/repo-only changes)

If `Major/breaking change`, describe the breaking behavior and migration steps.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls in this pull request.
