### PR TITLE
fix: relax validateconfig handling for unknown values

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -221,105 +221,6 @@ func (p *awsAppStreamProvider) ValidateConfig(ctx context.Context, req provider.
 		return
 	}
 
-	if config.AccessKey.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("access_key"),
-			"Unknown AWS Access Key",
-			"The AWS AppStream provider cannot be configured because \"access_key\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"access_key\" to a fixed string or remove it to use the AWS SDK default.",
-		)
-		return
-	}
-
-	if config.SecretAccessKey.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("secret_access_key"),
-			"Unknown AWS Secret Access Key",
-			"The AWS AppStream provider cannot be configured because \"secret_access_key\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"secret_access_key\" to a fixed string or remove it to use the AWS SDK default.",
-		)
-		return
-	}
-
-	if config.SessionToken.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("session_token"),
-			"Unknown AWS Session Token",
-			"The AWS AppStream provider cannot be configured because \"session_token\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"session_token\" to a fixed string or remove it to use the AWS SDK default.",
-		)
-		return
-	}
-
-	if config.Profile.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("profile"),
-			"Unknown AWS Profile",
-			"The AWS AppStream provider cannot be configured because \"profile\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"profile\" to a fixed string or remove it to use the AWS SDK default.",
-		)
-		return
-	}
-
-	if config.Region.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("region"),
-			"Unknown AWS Region",
-			"The AWS AppStream provider cannot be configured because \"region\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"region\" to a fixed string or remove it to use the AWS SDK default.",
-		)
-		return
-	}
-
-	if config.RetryMode.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("retry_mode"),
-			"Unknown AWS Retry Mode",
-			"The AWS AppStream provider cannot be configured because \"retry_mode\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"retry_mode\" to a fixed value or remove it to use the default.",
-		)
-		return
-	}
-
-	if config.RetryMaxAttempts.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("retry_max_attempts"),
-			"Unknown AWS Retry Max Attempts",
-			"The AWS AppStream provider cannot be configured because \"retry_max_attempts\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set it to a fixed number or remove it to use the default.",
-		)
-		return
-	}
-
-	if config.RetryMaxBackoff.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("retry_max_backoff"),
-			"Unknown AWS Retry Max Backoff",
-			"The AWS AppStream provider cannot be configured because \"retry_max_backoff\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set it to a fixed number or remove it to use the default.",
-		)
-		return
-	}
-
-	if config.DefaultTags != nil && config.DefaultTags.Tags.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("default_tags").AtName("tags"),
-			"Unknown Default Tags",
-			"The AWS AppStream provider cannot be configured because \"default_tags.tags\" is unknown. "+
-				"Provider configuration values must be static. "+
-				"Set \"default_tags.tags\" to a fixed map or remove it to use no default tags.",
-		)
-		return
-	}
-
 	hasAccessKey := !config.AccessKey.IsNull()
 	hasSecretKey := !config.SecretAccessKey.IsNull()
 	hasSession := !config.SessionToken.IsNull()
@@ -374,15 +275,15 @@ func (p *awsAppStreamProvider) Configure(ctx context.Context, req provider.Confi
 		return
 	}
 
-	hasAccessKey := !config.AccessKey.IsNull()
-	hasSecretKey := !config.SecretAccessKey.IsNull()
+	hasAccessKey := !config.AccessKey.IsNull() && !config.AccessKey.IsUnknown()
+	hasSecretKey := !config.SecretAccessKey.IsNull() && !config.SecretAccessKey.IsUnknown()
 	useStaticCreds := hasAccessKey && hasSecretKey
-	hasSession := !config.SessionToken.IsNull()
-	hasProfile := !config.Profile.IsNull()
-	hasRegion := !config.Region.IsNull()
-	hasRetryMode := !config.RetryMode.IsNull()
-	hasRetryMaxAttempts := !config.RetryMaxAttempts.IsNull()
-	hasRetryMaxBackoff := !config.RetryMaxBackoff.IsNull()
+	hasSession := !config.SessionToken.IsNull() && !config.SessionToken.IsUnknown()
+	hasProfile := !config.Profile.IsNull() && !config.Profile.IsUnknown()
+	hasRegion := !config.Region.IsNull() && !config.Region.IsUnknown()
+	hasRetryMode := !config.RetryMode.IsNull() && !config.RetryMode.IsUnknown()
+	hasRetryMaxAttempts := !config.RetryMaxAttempts.IsNull() && !config.RetryMaxAttempts.IsUnknown()
+	hasRetryMaxBackoff := !config.RetryMaxBackoff.IsNull() && !config.RetryMaxBackoff.IsUnknown()
 	retryConfigured := hasRetryMode || hasRetryMaxAttempts || hasRetryMaxBackoff
 
 	var awsopts []func(*awsconfig.LoadOptions) error
@@ -498,7 +399,7 @@ func (p *awsAppStreamProvider) Configure(ctx context.Context, req provider.Confi
 
 	defaultTags := map[string]string{}
 
-	if config.DefaultTags != nil && !config.DefaultTags.Tags.IsNull() {
+	if config.DefaultTags != nil && !config.DefaultTags.Tags.IsNull() && !config.DefaultTags.Tags.IsUnknown() {
 		diags := config.DefaultTags.Tags.ElementsAs(ctx, &defaultTags, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {

--- a/internal/resources/app_block/resource.go
+++ b/internal/resources/app_block/resource.go
@@ -47,47 +47,54 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 
 	// determine packaging type (aws defaults to CUSTOM if unset)
 	packagingType := "CUSTOM"
-	if !config.PackagingType.IsNull() && !config.PackagingType.IsUnknown() {
+	validatePackagingSpecific := true
+	switch {
+	case config.PackagingType.IsNull():
+	case config.PackagingType.IsUnknown():
+		validatePackagingSpecific = false
+	default:
 		packagingType = config.PackagingType.ValueString()
 	}
 
-	hasSetupScript := !config.SetupScriptDetails.IsNull() && !config.SetupScriptDetails.IsUnknown()
-	hasPostSetupScript := !config.PostSetupScriptDetails.IsNull() && !config.PostSetupScriptDetails.IsUnknown()
+	hasSetupScript := !config.SetupScriptDetails.IsNull()
+	hasPostSetupScript := !config.PostSetupScriptDetails.IsNull()
 
-	switch packagingType {
+	if validatePackagingSpecific {
+		switch packagingType {
 
-	case "CUSTOM":
-		// setup script is mandatory
-		if !hasSetupScript {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("setup_script_details"),
-				"Missing Required Attribute",
-				"`setup_script_details` must be specified when `packaging_type` is `CUSTOM`.",
-			)
-		}
+		case "CUSTOM":
+			// setup script is mandatory
+			if !hasSetupScript {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("setup_script_details"),
+					"Missing Required Attribute",
+					"`setup_script_details` must be specified when `packaging_type` is `CUSTOM`.",
+				)
+			}
 
-		// post-setup script not allowed
-		if hasPostSetupScript {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("post_setup_script_details"),
-				"Invalid Configuration",
-				"`post_setup_script_details` can only be specified when `packaging_type` is `APPSTREAM2`.",
-			)
-		}
+			// post-setup script not allowed
+			if hasPostSetupScript {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("post_setup_script_details"),
+					"Invalid Configuration",
+					"`post_setup_script_details` can only be specified when `packaging_type` is `APPSTREAM2`.",
+				)
+			}
 
-	case "APPSTREAM2":
-		// setup script not allowed
-		if hasSetupScript {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("setup_script_details"),
-				"Invalid Configuration",
-				"`setup_script_details` cannot be specified when `packaging_type` is `APPSTREAM2`.",
-			)
+		case "APPSTREAM2":
+			// setup script not allowed
+			if hasSetupScript {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("setup_script_details"),
+					"Invalid Configuration",
+					"`setup_script_details` cannot be specified when `packaging_type` is `APPSTREAM2`.",
+				)
+			}
 		}
 	}
 
 	// validate source_s3_location.s3_key requirements
-	if !config.SourceS3Location.IsNull() && !config.SourceS3Location.IsUnknown() {
+	if validatePackagingSpecific && !config.SourceS3Location.IsNull() && !config.SourceS3Location.IsUnknown() {
 		var source resourceModelSourceS3Location
 
 		resp.Diagnostics.Append(
@@ -97,7 +104,7 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 			return
 		}
 
-		hasS3Key := !source.S3Key.IsNull() && !source.S3Key.IsUnknown()
+		hasS3Key := !source.S3Key.IsNull()
 
 		if packagingType == "CUSTOM" && !hasS3Key {
 			resp.Diagnostics.AddAttributeError(

--- a/internal/resources/fleet/expand_test.go
+++ b/internal/resources/fleet/expand_test.go
@@ -112,6 +112,7 @@ func TestExpandVPCConfig(t *testing.T) {
 
 	if got == nil {
 		t.Fatalf("expected VpcConfig, got nil")
+		return
 	}
 
 	if !reflect.DeepEqual(got.SubnetIds, []string{"subnet-1"}) {
@@ -145,6 +146,7 @@ func TestExpandDomainJoinInfo(t *testing.T) {
 
 	if got == nil {
 		t.Fatalf("expected DomainJoinInfo, got nil")
+		return
 	}
 
 	if aws.ToString(got.DirectoryName) != "example.com" {
@@ -174,6 +176,7 @@ func TestExpandSessionScriptS3Location(t *testing.T) {
 
 	if got == nil {
 		t.Fatalf("expected S3Location, got nil")
+		return
 	}
 
 	if aws.ToString(got.S3Bucket) != "bucket" {

--- a/internal/resources/fleet/resource.go
+++ b/internal/resources/fleet/resource.go
@@ -45,8 +45,8 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 		return
 	}
 
-	hasImageName := !config.ImageName.IsNull() && !config.ImageName.IsUnknown()
-	hasImageArn := !config.ImageARN.IsNull() && !config.ImageARN.IsUnknown()
+	hasImageName := !config.ImageName.IsNull()
+	hasImageArn := !config.ImageARN.IsNull()
 
 	fleetType := config.FleetType.ValueString()
 	switch fleetType {
@@ -115,30 +115,32 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 			)
 		}
 
-		var vpc resourceModelVPCConfig
-		resp.Diagnostics.Append(
-			config.VPCConfig.As(ctx, &vpc, basetypes.ObjectAsOptions{})...,
-		)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		// subnets are mandatory for elastic fleets
-		if vpc.SubnetIDs.IsNull() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("vpc_config").AtName("subnet_ids"),
-				"Missing Required Attribute",
-				"`subnet_ids` must be specified for elastic fleets.",
+		if !config.VPCConfig.IsUnknown() {
+			var vpc resourceModelVPCConfig
+			resp.Diagnostics.Append(
+				config.VPCConfig.As(ctx, &vpc, basetypes.ObjectAsOptions{})...,
 			)
-		} else if !vpc.SubnetIDs.IsUnknown() {
-			// aws requires at least two subnets in different AZs
-			subnets := vpc.SubnetIDs.Elements()
-			if len(subnets) < 2 {
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			// subnets are mandatory for elastic fleets
+			if vpc.SubnetIDs.IsNull() {
 				resp.Diagnostics.AddAttributeError(
 					path.Root("vpc_config").AtName("subnet_ids"),
-					"Invalid VPC Configuration",
-					"Elastic fleets require at least two subnets in different availability zones.",
+					"Missing Required Attribute",
+					"`subnet_ids` must be specified for elastic fleets.",
 				)
+			} else if !vpc.SubnetIDs.IsUnknown() {
+				// aws requires at least two subnets in different AZs
+				subnets := vpc.SubnetIDs.Elements()
+				if len(subnets) < 2 {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("vpc_config").AtName("subnet_ids"),
+						"Invalid VPC Configuration",
+						"Elastic fleets require at least two subnets in different availability zones.",
+					)
+				}
 			}
 		}
 
@@ -188,7 +190,7 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 		}
 
 		// platform is only supported for elastic fleets
-		if !config.Platform.IsNull() && !config.Platform.IsUnknown() {
+		if !config.Platform.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("platform"),
 				"Invalid Configuration",
@@ -206,48 +208,50 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 			return
 		}
 
-		var capacity resourceModelComputeCapacity
-		resp.Diagnostics.Append(
-			config.ComputeCapacity.As(ctx, &capacity, basetypes.ObjectAsOptions{})...,
-		)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		hasDesiredInstances := !capacity.DesiredInstances.IsNull() && !capacity.DesiredInstances.IsUnknown()
-		hasDesiredSessions := !capacity.DesiredSessions.IsNull() && !capacity.DesiredSessions.IsUnknown()
-
-		switch {
-		// aws requires exactly one of instances or sessions
-		case hasDesiredInstances && hasDesiredSessions:
-			resp.Diagnostics.AddAttributeError(
-				path.Root("compute_capacity"),
-				"Invalid Compute Capacity Configuration",
-				"Only one of `desired_instances` or `desired_sessions` may be specified.",
+		if !config.ComputeCapacity.IsUnknown() {
+			var capacity resourceModelComputeCapacity
+			resp.Diagnostics.Append(
+				config.ComputeCapacity.As(ctx, &capacity, basetypes.ObjectAsOptions{})...,
 			)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 
-		case !hasDesiredInstances && !hasDesiredSessions:
-			resp.Diagnostics.AddAttributeError(
-				path.Root("compute_capacity"),
-				"Missing Required Attribute",
-				"Exactly one of `desired_instances` or `desired_sessions` must be specified for non-elastic fleets.",
-			)
+			hasDesiredInstances := !capacity.DesiredInstances.IsNull()
+			hasDesiredSessions := !capacity.DesiredSessions.IsNull()
 
-		// desired_sessions implies a multi-session fleet
-		case hasDesiredSessions:
-			if config.MaxSessionsPerInstance.IsNull() || config.MaxSessionsPerInstance.IsUnknown() {
+			switch {
+			// aws requires exactly one of instances or sessions
+			case hasDesiredInstances && hasDesiredSessions:
 				resp.Diagnostics.AddAttributeError(
-					path.Root("compute_capacity").AtName("desired_sessions"),
+					path.Root("compute_capacity"),
 					"Invalid Compute Capacity Configuration",
-					"`desired_sessions` can only be used for multi-session fleets. "+
-						"Set `max_sessions_per_instance` to a value greater than 1.",
+					"Only one of `desired_instances` or `desired_sessions` may be specified.",
 				)
-			} else if config.MaxSessionsPerInstance.ValueInt32() <= 1 {
+
+			case !hasDesiredInstances && !hasDesiredSessions:
 				resp.Diagnostics.AddAttributeError(
-					path.Root("compute_capacity").AtName("desired_sessions"),
-					"Invalid Compute Capacity Configuration",
-					"`desired_sessions` requires `max_sessions_per_instance` to be greater than 1.",
+					path.Root("compute_capacity"),
+					"Missing Required Attribute",
+					"Exactly one of `desired_instances` or `desired_sessions` must be specified for non-elastic fleets.",
 				)
+
+			// desired_sessions implies a multi-session fleet
+			case hasDesiredSessions:
+				if config.MaxSessionsPerInstance.IsNull() {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("compute_capacity").AtName("desired_sessions"),
+						"Invalid Compute Capacity Configuration",
+						"`desired_sessions` can only be used for multi-session fleets. "+
+							"Set `max_sessions_per_instance` to a value greater than 1.",
+					)
+				} else if !config.MaxSessionsPerInstance.IsUnknown() && config.MaxSessionsPerInstance.ValueInt32() <= 1 {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("compute_capacity").AtName("desired_sessions"),
+						"Invalid Compute Capacity Configuration",
+						"`desired_sessions` requires `max_sessions_per_instance` to be greater than 1.",
+					)
+				}
 			}
 		}
 	}

--- a/internal/resources/image/data_source.go
+++ b/internal/resources/image/data_source.go
@@ -39,9 +39,9 @@ func (ds *dataSource) ValidateConfig(ctx context.Context, req datasource.Validat
 		return
 	}
 
-	hasArn := !config.ARN.IsNull() && !config.ARN.IsUnknown()
-	hasName := !config.Name.IsNull() && !config.Name.IsUnknown()
-	hasNameRegex := !config.NameRegex.IsNull() && !config.NameRegex.IsUnknown()
+	hasArn := !config.ARN.IsNull()
+	hasName := !config.Name.IsNull()
+	hasNameRegex := !config.NameRegex.IsNull()
 
 	selectionCount := 0
 	if hasArn {

--- a/internal/resources/image_builder/expand_test.go
+++ b/internal/resources/image_builder/expand_test.go
@@ -115,6 +115,7 @@ func TestExpandDomainJoinInfo(t *testing.T) {
 
 	if got == nil {
 		t.Fatalf("expected DomainJoinInfo, got nil")
+		return
 	}
 
 	if aws.ToString(got.DirectoryName) != "corp.example.com" {

--- a/internal/resources/image_builder/resource.go
+++ b/internal/resources/image_builder/resource.go
@@ -42,8 +42,8 @@ func (r *resource) ValidateConfig(ctx context.Context, req tfresource.ValidateCo
 		return
 	}
 
-	hasImageName := !config.ImageName.IsNull() && !config.ImageName.IsUnknown()
-	hasImageArn := !config.ImageARN.IsNull() && !config.ImageARN.IsUnknown()
+	hasImageName := !config.ImageName.IsNull()
+	hasImageArn := !config.ImageARN.IsNull()
 
 	// can either have image name or image arn
 	switch {

--- a/internal/resources/sessions/data_source.go
+++ b/internal/resources/sessions/data_source.go
@@ -38,8 +38,8 @@ func (ds *dataSource) ValidateConfig(ctx context.Context, req datasource.Validat
 		return
 	}
 
-	if !config.UserID.IsNull() && !config.UserID.IsUnknown() {
-		if config.AuthenticationType.IsNull() || config.AuthenticationType.IsUnknown() {
+	if !config.UserID.IsNull() {
+		if config.AuthenticationType.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("authentication_type"),
 				"Invalid Session Filter Configuration",

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	opts := providerserver.ServeOpts{
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "registry.terraform.io/st3ffn/awsappstream",
+		Address: "registry.terraform.io/st3ffn/aws-appstream",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
## Related Issue

Fixes: #135 

Commit style:
- Commits in this PR must comply with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (`type(scope): description`).

## Description

This PR relaxes overly strict `ValidateConfig` handling so provider, resource, and data source validation no longer treats unknown Terraform values as absent too early.

Key updates:
- Relaxed provider `ValidateConfig` handling for unresolved authentication inputs.
- Fixed presence-based validation in `awsappstream_image` and `awsappstream_image_builder` to count non-null values as provided, even when still unknown.
- Relaxed overly strict validation in `awsappstream_app_block`, `awsappstream_sessions`, and `awsappstream_fleet`.
- Adjusted nested validation paths so unknown parent objects defer validation instead of failing early.
- Added or updated tests around image state filtering and expand helpers while validating related changes.

Design choice:
The main design choice in this PR is to treat validation rules that ask “was this argument provided?” differently from rules that require a known final value. For presence-style checks, using `!IsNull()` is more correct than requiring `!IsUnknown()`, because Terraform may legitimately pass unresolved values during validation. This keeps real validation in place while avoiding false failures for valid configurations.

## Release Impact

Select one:
- [x] Hotfix (patch)
- [ ] Minor change
- [ ] Major/breaking change
- [ ] No provider behavior change (docs/CI/repo-only changes)

If `Major/breaking change`, describe the breaking behavior and migration steps.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls in this pull request.
