### PR TITLE
feat: handle resourcegroupstaggingapi rate-limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,15 +7,15 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.57.1
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.298.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.11
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
-	github.com/aws/smithy-go v1.25.0
+	github.com/aws/smithy-go v1.25.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/hashicorp/terraform-plugin-testing v1.15.0
+	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -50,7 +50,7 @@ require (
 	github.com/hashicorp/hc-install v0.9.4 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.25.0 // indirect
+	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 h1:FPXsW9+gMuIeKmz7j6ENWcWtBGT
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23/go.mod h1:7J8iGMdRKk6lw2C+cMIphgAnT8uTwBwNOsGkyOCm80U=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.57.1 h1:CiCgPDYEn70zYc+kmm7g27IZx3sBWXYATlSuV0cnGCU=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.57.1/go.mod h1:qv9Smf3bIg1fu9zXv3lu1ZKSCeuornNp6faT5WcW8Wg=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.298.0 h1:PP4/BDTcOWR9Sr64K3atzu2738pmNLiFzJ70lxS3Yno=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.298.0/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0 h1:qTozRFl2YFFU2HJGl7ZAywlRQvBnAN591gbAFT5bE0s=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 h1:HtOTYcbVcGABLOVuPYaIihj6IlkqubBwFj10K5fxRek=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8/go.mod h1:VsK9abqQeGlzPgUr+isNWzPlK2vKe9INMLWnY65f5Xs=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 h1:PUmZeJU6Y1Lbvt9WFuJ0ugUK2xn6hIWUBBbKuOWF30s=
@@ -41,8 +41,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 h1:oK/njaL8GtyEihkWMD4k3Vg
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20/go.mod h1:JHs8/y1f3zY7U5WcuzoJ/yAYGYtNIVPKLIbp61euvmg=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 h1:ks8KBcZPh3PYISr5dAiXCM5/Thcuxk8l+PG4+A0exds=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0/go.mod h1:pFw33T0WLvXU3rw1WBkpMlkgIn54eCB5FYLhjDc9Foo=
-github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
-github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -114,8 +114,8 @@ github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQx
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.25.0 h1:Bkt6m3VkJqYh+laFMrWIpy9KHYFITpOyzRMNI35rNaY=
-github.com/hashicorp/terraform-exec v0.25.0/go.mod h1:dl9IwsCfklDU6I4wq9/StFDp7dNbH/h5AnfS1RmiUl8=
+github.com/hashicorp/terraform-exec v0.25.1 h1:PRutYRGM8pixV3B8812NYoBK5O+yuf3qcB/70KFKGiU=
+github.com/hashicorp/terraform-exec v0.25.1/go.mod h1:+izOYrs9sKMQK4OYvGDnrSSJHY/pm4e4eXFqSL2Q5mA=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
@@ -128,8 +128,8 @@ github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3Obj
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 h1:MKS/2URqeJRwJdbOfcbdsZCq/IRrNkqJNN0GtVIsuGs=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0/go.mod h1:PuG4P97Ju3QXW6c6vRkRadWJbvnEu2Xh+oOuqcYOqX4=
-github.com/hashicorp/terraform-plugin-testing v1.15.0 h1:/fimKyl0YgD7aAtJkuuAZjwBASXhCIwWqMbDLnKLMe4=
-github.com/hashicorp/terraform-plugin-testing v1.15.0/go.mod h1:bGXMw7bE95EiZhSBV3rM2W8TiffaPTDuLS+HFI/lIYs=
+github.com/hashicorp/terraform-plugin-testing v1.16.0 h1:GB97nGnJ1hESpDrCjqZig38RodSF0gdRzxlDupLXP38=
+github.com/hashicorp/terraform-plugin-testing v1.16.0/go.mod h1:eQPYAy9xFMV7xtIFX8Y+wJGtUB++HBl329zCF6PBMZk=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=
 github.com/hashicorp/terraform-registry-address v0.4.0/go.mod h1:LRS1Ay0+mAiRkUyltGT+UHWkIqTFvigGn/LbMshfflE=
 github.com/hashicorp/terraform-svchost v0.2.1 h1:ubvrTFw3Q7CsoEaX7V06PtCTKG3wu7GyyobAoN4eF3Q=
@@ -146,9 +146,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/internal/resources/stack/expand_test.go
+++ b/internal/resources/stack/expand_test.go
@@ -596,6 +596,7 @@ func TestExpandStreamingExperienceSettings(t *testing.T) {
 
 			if got == nil {
 				t.Fatalf("expected %#v, got nil", tt.want)
+				return
 			}
 
 			if got.PreferredProtocol != tt.want.PreferredProtocol {

--- a/internal/tags/retry.go
+++ b/internal/tags/retry.go
@@ -1,0 +1,12 @@
+// Copyright St3ffn 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tags
+
+import "time"
+
+const (
+	taggingRetryTimeout     = 5 * time.Minute
+	taggingRetryInitBackoff = 2 * time.Second
+	taggingRetryMaxBackoff  = 30 * time.Second
+)

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -6,14 +6,14 @@ package tags
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstaggingapi "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
-	awstaggingtypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/aws/smithy-go"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/st3ffn/terraform-provider-aws-appstream/internal/util"
 )
 
 type taggingAPI interface {
@@ -129,14 +129,41 @@ func (tm *TagManager) Apply(
 	removeKeys, addOrUpdate := diffTags(current, desiredTags)
 
 	if len(removeKeys) > 0 {
-		out, err := tm.client.UntagResources(
+		err := util.RetryOn(
 			ctx,
-			&awstaggingapi.UntagResourcesInput{
-				ResourceARNList: []string{arn},
-				TagKeys:         removeKeys,
+			func(ctx context.Context) error {
+				out, err := tm.client.UntagResources(
+					ctx,
+					&awstaggingapi.UntagResourcesInput{
+						ResourceARNList: []string{arn},
+						TagKeys:         removeKeys,
+					},
+					optFns...,
+				)
+				if err != nil {
+					return err
+				}
+
+				if out != nil && len(out.FailedResourcesMap) > 0 {
+					for _, failedResource := range out.FailedResourcesMap {
+						return &smithy.GenericAPIError{
+							Code:    string(failedResource.ErrorCode),
+							Message: aws.ToString(failedResource.ErrorMessage),
+						}
+					}
+				}
+
+				return err
 			},
-			optFns...,
+			util.WithTimeout(taggingRetryTimeout),
+			util.WithInitBackoff(taggingRetryInitBackoff),
+			util.WithMaxBackoff(taggingRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_UntagResources.html
+			util.WithRetryOnFns(
+				util.IsThrottledException,
+			),
 		)
+
 		if err != nil {
 			diags.AddError(
 				"Error Removing AWS Tags",
@@ -144,29 +171,44 @@ func (tm *TagManager) Apply(
 			)
 			return types.MapNull(types.StringType), diags
 		}
-
-		if out != nil && len(out.FailedResourcesMap) > 0 {
-			diags.AddError(
-				"Error Removing AWS Tags",
-				fmt.Sprintf(
-					"Could not remove tags from resource %q because AWS reported failed resources: %s",
-					arn,
-					formatFailedResources(out.FailedResourcesMap),
-				),
-			)
-			return types.MapNull(types.StringType), diags
-		}
 	}
 
 	if len(addOrUpdate) > 0 {
-		out, err := tm.client.TagResources(
+		err := util.RetryOn(
 			ctx,
-			&awstaggingapi.TagResourcesInput{
-				ResourceARNList: []string{arn},
-				Tags:            addOrUpdate,
+			func(ctx context.Context) error {
+				out, err := tm.client.TagResources(
+					ctx,
+					&awstaggingapi.TagResourcesInput{
+						ResourceARNList: []string{arn},
+						Tags:            addOrUpdate,
+					},
+					optFns...,
+				)
+				if err != nil {
+					return err
+				}
+
+				if out != nil && len(out.FailedResourcesMap) > 0 {
+					for _, failedResource := range out.FailedResourcesMap {
+						return &smithy.GenericAPIError{
+							Code:    string(failedResource.ErrorCode),
+							Message: aws.ToString(failedResource.ErrorMessage),
+						}
+					}
+				}
+
+				return err
 			},
-			optFns...,
+			util.WithTimeout(taggingRetryTimeout),
+			util.WithInitBackoff(taggingRetryInitBackoff),
+			util.WithMaxBackoff(taggingRetryMaxBackoff),
+			// see https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_TagResources.html
+			util.WithRetryOnFns(
+				util.IsThrottledException,
+			),
 		)
+
 		if err != nil {
 			diags.AddError(
 				"Error Updating AWS Tags",
@@ -174,53 +216,9 @@ func (tm *TagManager) Apply(
 			)
 			return types.MapNull(types.StringType), diags
 		}
-
-		if out != nil && len(out.FailedResourcesMap) > 0 {
-			diags.AddError(
-				"Error Updating AWS Tags",
-				fmt.Sprintf(
-					"Could not update tags for resource %q because AWS reported failed resources: %s",
-					arn,
-					formatFailedResources(out.FailedResourcesMap),
-				),
-			)
-			return types.MapNull(types.StringType), diags
-		}
 	}
 
 	return flattenTags(ctx, desiredTags, &diags), diags
-}
-
-func formatFailedResources(failed map[string]awstaggingtypes.FailureInfo) string {
-	if len(failed) == 0 {
-		return ""
-	}
-
-	arns := make([]string, 0, len(failed))
-	for arn := range failed {
-		arns = append(arns, arn)
-	}
-	sort.Strings(arns)
-
-	parts := make([]string, 0, len(arns))
-	for _, arn := range arns {
-		info := failed[arn]
-
-		code := string(info.ErrorCode)
-		if code == "" {
-			code = "UnknownError"
-		}
-
-		part := fmt.Sprintf("%s (code=%s status=%d", arn, code, info.StatusCode)
-		if info.ErrorMessage != nil && *info.ErrorMessage != "" {
-			part += fmt.Sprintf(" message=%q", *info.ErrorMessage)
-		}
-		part += ")"
-
-		parts = append(parts, part)
-	}
-
-	return strings.Join(parts, "; ")
 }
 
 func flattenTags(ctx context.Context, tags map[string]string, diags *diag.Diagnostics) types.Map {

--- a/internal/util/aws.go
+++ b/internal/util/aws.go
@@ -74,6 +74,11 @@ func IsAppStreamNotFound(err error) bool {
 	return IsAWSAPIError(err, "ResourceNotFoundException", "EntitlementNotFoundException")
 }
 
+// IsThrottledException reports whether err is a ThrottledException or ThrottlingException.
+func IsThrottledException(err error) bool {
+	return IsAWSAPIError(err, "ThrottledException", "ThrottlingException")
+}
+
 // AWSEnumToSlice converts an AWS SDK enum value list function into a []string.
 func AWSEnumToSlice[T ~string](awsEnumValuesFunc func(T) []T) []string {
 	var zero T

--- a/internal/util/aws_test.go
+++ b/internal/util/aws_test.go
@@ -209,6 +209,30 @@ func TestErrorPredicates(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "throttling/throttled_exception_match",
+			err:  &smithy.GenericAPIError{Code: "ThrottledException"},
+			fn:   IsThrottledException,
+			want: true,
+		},
+		{
+			name: "throttling/throttling_exception_match",
+			err:  &smithy.GenericAPIError{Code: "ThrottlingException"},
+			fn:   IsThrottledException,
+			want: true,
+		},
+		{
+			name: "throttling/no_match",
+			err:  &smithy.GenericAPIError{Code: "other"},
+			fn:   IsThrottledException,
+			want: false,
+		},
+		{
+			name: "throttling/no_match_nil",
+			err:  nil,
+			fn:   IsThrottledException,
+			want: false,
+		},
+		{
 			name: "non_aws_error",
 			err:  errors.New("plain error"),
 			fn:   IsResourceNotFoundException,

--- a/tools/provider-codegen/go.mod
+++ b/tools/provider-codegen/go.mod
@@ -44,11 +44,11 @@ require (
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.25.0 // indirect
+	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jedib0t/go-pretty/v6 v6.7.9 // indirect
+	github.com/jedib0t/go-pretty/v6 v6.7.10 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect

--- a/tools/provider-codegen/go.sum
+++ b/tools/provider-codegen/go.sum
@@ -217,8 +217,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
-github.com/hashicorp/terraform-exec v0.25.0 h1:Bkt6m3VkJqYh+laFMrWIpy9KHYFITpOyzRMNI35rNaY=
-github.com/hashicorp/terraform-exec v0.25.0/go.mod h1:dl9IwsCfklDU6I4wq9/StFDp7dNbH/h5AnfS1RmiUl8=
+github.com/hashicorp/terraform-exec v0.25.1 h1:PRutYRGM8pixV3B8812NYoBK5O+yuf3qcB/70KFKGiU=
+github.com/hashicorp/terraform-exec v0.25.1/go.mod h1:+izOYrs9sKMQK4OYvGDnrSSJHY/pm4e4eXFqSL2Q5mA=
 github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a h1:T7AMR21kjrbeEpN+KhGlyd31XXHsSZF5zg+ivfeYte4=
 github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a/go.mod h1:yjb5C2W07l8lmAzdyVgOLji0/D2IoHkR3rusBzUO4O0=
 github.com/hashicorp/terraform-plugin-docs v0.25.0 h1:qHs1V257NxVe8tv6HS4UQfNqjaPP5eUlLeDf7jYk85U=
@@ -237,8 +237,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jedib0t/go-pretty/v6 v6.7.9 h1:frarzQWmkZd97syT81+TH8INKPpzoxQnk+Mk5EIHSrM=
-github.com/jedib0t/go-pretty/v6 v6.7.9/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/jedib0t/go-pretty/v6 v6.7.10 h1:B/2qW2Bkv2L6n14PP8o1kx75kWzHOQ3YTluWzg9icac=
+github.com/jedib0t/go-pretty/v6 v6.7.10/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=


### PR DESCRIPTION
## Related Issue

Fixes: #138 

Commit style:
- Commits in this PR must comply with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (`type(scope): description`).

## Description

Add retry handling for transient throttling failures returned by AWS Resource Groups Tagging API during tag reconciliation.

Key updates:
- Wrapped `TagResources` and `UntagResources` calls with the provider's existing `util.RetryOn` helper.
- Added tagging retry defaults with a 5 minute timeout, 2 second initial backoff, and 30 second max backoff.
- Added `util.IsThrottledException` to match both `ThrottledException` and `ThrottlingException`.
- Converts `FailedResourcesMap` entries into Smithy API errors so per-resource throttling responses can be retried.
- Added predicate test coverage for both Resource Groups top-level throttling and failed-resource throttling error names.
- Updated dependency lock files and a stack test guard as part of the current staged changes.

Design choice:
The retry is implemented in the shared tagging layer instead of individual resources so all resources using provider-managed tags benefit consistently. The retry predicate intentionally matches both `ThrottledException` and `ThrottlingException` because Resource Groups Tagging API can expose throttling under different names depending on whether the failure is returned as a top-level SDK error or inside `FailedResourcesMap`.

## Release Impact

Select one:
- [x] Hotfix (patch)
- [ ] Minor change
- [ ] Major/breaking change
- [ ] No provider behavior change (docs/CI/repo-only changes)

If `Major/breaking change`, describe the breaking behavior and migration steps.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls in this pull request.
